### PR TITLE
chore: finish standalone repository hygiene

### DIFF
--- a/.agents/notes/proposed/architecture/2026-08-19-dsh-edge-standalone-wrapper.i18n.yaml
+++ b/.agents/notes/proposed/architecture/2026-08-19-dsh-edge-standalone-wrapper.i18n.yaml
@@ -2,5 +2,5 @@
 # last confirmed-consistent state. Both languages carry equal authority.
 # After editing either side, update both and re-record every pair with:
 #   pnpm run doc-pairs -- --write
-2026-08-19-dsh-edge-standalone-wrapper.md: 68ace95055388e60433a1026da6321936082e36e
-2026-08-19-dsh-edge-standalone-wrapper.zh.md: 5f000a12bfbea331ec5ba7291e3e857ca2281dae
+2026-08-19-dsh-edge-standalone-wrapper.md: 48bcdc0d16afbee1ee446a78a693fd34a7051c47
+2026-08-19-dsh-edge-standalone-wrapper.zh.md: 91df23c74fc4355c63d9e5138317bb5e6e0a7911

--- a/.agents/notes/proposed/architecture/2026-08-19-dsh-edge-standalone-wrapper.md
+++ b/.agents/notes/proposed/architecture/2026-08-19-dsh-edge-standalone-wrapper.md
@@ -6,7 +6,7 @@ English | [中文](2026-08-19-dsh-edge-standalone-wrapper.zh.md)
 
 ## Problem
 
-DSH Edge is maintained as a source fork of DeepSeek Harness even though its product-owned implementation is limited to the Cloudflare runtime, installer, Edge client plugin, deployment modes, and a small set of upstream adaptations. The fork carries unrelated upstream source, governance, CI, release families, and documentation machinery, so an upstream update looks like a repository-wide merge and DSH Edge ownership remains unclear.
+DSH Edge began as a source fork of DeepSeek Harness even though its product-owned implementation was limited to the Cloudflare runtime, installer, Edge client plugin, deployment modes, and a small set of upstream adaptations. The fork carried unrelated upstream source, governance, CI, release families, and documentation machinery, so an upstream update looked like a repository-wide merge and DSH Edge ownership remained unclear.
 
 The 0.2 release needs to consume an exact published Harness version, assemble the upstream application without copying its repository, and retain only patches that cannot use supported extension points. The migration must preserve the released 0.1.3 behavior and durable data while keeping every merged `master` revision buildable, deployable, and releasable.
 
@@ -29,17 +29,17 @@ The standalone repository owns the Cloudflare Worker, Direct and Dynamic Loader 
 
 ### Progress protocol
 
-Each PR has one status: `planned`, `in progress`, `in review`, `merged`, or `blocked`. An acceptance item is checked only when its Evidence field names the command, artifact, test, or deployment that proves it. Scope or acceptance changes are appended to the Change log with a reason; criteria are never weakened silently.
+Each stage has one status: `planned`, `in progress`, `in review`, `merged`, or `blocked`. An acceptance item is checked only when its Evidence field names the command, artifact, test, or deployment that proves it. Scope or acceptance changes are appended to the Change log with a reason; criteria are never weakened silently. Stages 1 through 4 are the original migration sequence whose GitHub work is archived as PRs 25 through 28; stages 5 through 7 describe the post-cutover release track and are not GitHub PR numbers.
 
-| PR | Objective | Status | Release | User action |
+| Stage | Objective | Status | Release | User action |
 | --- | --- | --- | --- | --- |
-| 1 | Freeze the 0.1.3 baseline | merged | none | none; [PR #25](https://github.com/pawaca/dsh-edge/pull/25) merged |
-| 2 | Add a parallel standalone assembly path | merged | none | none; [PR #26](https://github.com/pawaca/dsh-edge/pull/26) merged |
-| 3 | Switch after rc.7 parity | merged | none | none; [PR #27](https://github.com/pawaca/dsh-edge/pull/27) merged |
-| 4 | Remove fork source and simplify governance | in review | `0.2.0-alpha.1` | approve prerelease; [PR #28](https://github.com/pawaca/dsh-edge/pull/28) opened |
-| 5 | Upgrade the exact upstream baseline | planned | `0.2.0-alpha.2` | approve prerelease |
-| 6 | Close distribution and installation | planned | `0.2.0-beta.1` | perform account-owned Cloudflare flows; approve beta |
-| 7 | Rehearse upgrade and release 0.2 | planned | `0.2.0` | approve production replacement and release |
+| 1 | Freeze the 0.1.3 baseline | merged | none | none; archived [PR #25](https://github.com/pawaca/dsh-edge-history/pull/25) merged |
+| 2 | Add a parallel standalone assembly path | merged | none | none; archived [PR #26](https://github.com/pawaca/dsh-edge-history/pull/26) merged |
+| 3 | Switch after rc.7 parity | merged | none | none; archived [PR #27](https://github.com/pawaca/dsh-edge-history/pull/27) merged |
+| 4 | Remove fork source and simplify governance | merged | none | none; archived [PR #28](https://github.com/pawaca/dsh-edge-history/pull/28) merged |
+| 5 | Close post-cutover hygiene and publish the rc.7 standalone baseline | in progress | `0.2.0-alpha.1` | approve prerelease after repository and release gates pass |
+| 6 | Upgrade the exact upstream baseline when a newer package set is published | planned | `0.2.0-alpha.2` | approve prerelease |
+| 7 | Rehearse canary upgrade, beta, rollback, and release 0.2 | planned | `0.2.0-beta.1`, then `0.2.0` | perform account-owned Cloudflare flows; approve beta and stable releases |
 
 ### PR 1 — Freeze the 0.1.3 baseline
 
@@ -56,7 +56,7 @@ Excluded: runtime behavior, data-format changes, Harness upgrades, source deleti
 - [x] Every non-Edge fork modification has a disposition: adapter, retained patch, upstream candidate, or deletion.
 - [x] Evidence names exact commands and artifacts.
 
-Evidence: `dsh-edge-0.1.3-session.sql` fixes the released SQL schema, one canonical turn, and one blank session. Its adapter test resumes and appends to the canonical session, promotes and writes the blank session, then reloads both. `dsh-edge-0.1.3-vfs.sql` fixes the released `@cloudflare/computer` 0.2.0 schema and content, while `dsh-edge-0.1.3-workspace.json` fixes the released workspace title, session ordering, and archive state. A test-only Durable Object seeder writes all three fixtures through native SQL and KV storage, then rejects foreign-key violations before the candidate Worker starts. The Miniflare integration then reads and extends the released VFS, requires the first continuation to reconstruct both released messages, promotes and persists the released blank session through production Worker APIs, and reads, renames, attaches to, and reloads the released workspace through RPC. Existing settings, preset, session, Web Search, HTTP, and WebSocket snapshots remain the UI and protocol fixtures. The persistence test passed 23 tests, the full session integration passed, and the browser snapshot suite passed 3 tests. `pnpm --filter dsh-edge run bundle:workers` reported Direct at 683,920 gzip bytes against the 921,600-byte repository budget and Dynamic Loader at 959.59 KiB gzip. Hosted [Edge CI run 32343433389](https://github.com/pawaca/dsh-edge/actions/runs/32343433389) passed on the reviewed head, and [PR #25](https://github.com/pawaca/dsh-edge/pull/25) merged as `b1627b0fd033b2efdcd1a5b09e4b3160b74a1e1c`.
+Evidence: `dsh-edge-0.1.3-session.sql` fixes the released SQL schema, one canonical turn, and one blank session. Its adapter test resumes and appends to the canonical session, promotes and writes the blank session, then reloads both. `dsh-edge-0.1.3-vfs.sql` fixes the released `@cloudflare/computer` 0.2.0 schema and content, while `dsh-edge-0.1.3-workspace.json` fixes the released workspace title, session ordering, and archive state. A test-only Durable Object seeder writes all three fixtures through native SQL and KV storage, then rejects foreign-key violations before the candidate Worker starts. The Miniflare integration then reads and extends the released VFS, requires the first continuation to reconstruct both released messages, promotes and persists the released blank session through production Worker APIs, and reads, renames, attaches to, and reloads the released workspace through RPC. Existing settings, preset, session, Web Search, HTTP, and WebSocket snapshots remain the UI and protocol fixtures. The persistence test passed 23 tests, the full session integration passed, and the browser snapshot suite passed 3 tests. `pnpm --filter dsh-edge run bundle:workers` reported Direct at 683,920 gzip bytes against the 921,600-byte repository budget and Dynamic Loader at 959.59 KiB gzip. Hosted [Edge CI run 32343433389](https://github.com/pawaca/dsh-edge-history/actions/runs/32343433389) passed on the reviewed head, and archived [PR #25](https://github.com/pawaca/dsh-edge-history/pull/25) merged as `b1627b0fd033b2efdcd1a5b09e4b3160b74a1e1c`.
 
 Current fork changes outside `apps/dsh-edge/**` and `packages/client/ui-edge/**` have these dispositions:
 
@@ -125,59 +125,62 @@ Excluded: runtime changes, review-tool rewrites, upstream upgrades, and removal 
 
 Evidence: a temporary checkout with no parent or root dependencies completed the frozen standalone install, both Worker builds, deterministic Web rebuild, six-patch and 28-client-plugin verification before the root install. The same Edge client source then produced byte-identical client bundles in two different absolute checkout paths (`37f005f9b979d20cd2f1ca08306ee8bd760b618d7bd106287a990d4c293cfc23`); the verifier rejects absolute checkout paths in release output. Direct measured 686,060 gzip bytes against the 921,600-byte budget and Dynamic Loader measured 961.63 KiB. The 20-file root suite passed 176 tests, both modes passed the full release-artifact integration, the three assembled-runtime/browser/installer snapshots passed, and Edge typecheck and type-aware lint passed. A fresh `dsh-edge-0.1.3.tgz` installed outside the workspace, started both prebuilt modes, and contained only release Web assets, Workers, installer/runtime scripts, bilingual package docs, and legal notices. The repository now has only `apps/dsh-edge` and `packages/client/ui-edge` as source workspaces; CI has only `edge-ci.yml` and `release-edge.yml`; root legal files attribute dsh-edge to pawaca while preserving DeepSeek's upstream MIT notice; root `AGENTS.md` owns the project rules and the real root `CLAUDE.md` points Claude Code to them.
 
-### PR 5 — Upgrade the upstream baseline
+### Stage 5 — Close post-cutover hygiene and publish alpha.1
 
-Objective: upgrade the standalone wrapper separately from source extraction.
+Objective: establish the clean-root repository as the trustworthy canonical source, then publish the behaviorally unchanged rc.7 standalone baseline as `0.2.0-alpha.1`.
 
-Scope: update exact dependencies from `0.1.0-rc.7` to the selected release, initially `0.1.0-rc.8`; regenerate assembly inputs; retire obsolete patches; classify new plugins and visible changes; retain Edge branding and exclude unsupported capabilities.
+Scope: preserve the archived development record; repair repository, security, dependency-automation, and bilingual-documentation hygiene; make prerelease update discovery channel-aware; require tags to identify reviewed `master`; create a matching GitHub prerelease only after npm publication succeeds; rerun the packed-artifact and parity evidence before publication.
 
-Excluded: deferred-plugin implementation, unrelated upstream defects, and persistence or authentication redesign.
+Excluded: upstream dependency upgrades, deferred-plugin implementation, runtime behavior changes, and commercial account management.
+
+- [x] The canonical repository is not a fork, has one clean root commit, and has the exact reviewed PR 4 tree.
+- [x] The archived repository retains PRs 25 through 28, their review history, and the 0.1.3 GitHub Release.
+- [ ] Public and contributor documentation identifies the archive, current security-reporting path, and supported install commands without stale links.
+- [ ] Dependency automation cannot split the coordinated root, standalone, legal-notice, and snapshot invariants into misleading green or permanently failing PRs.
+- [ ] Stable deployments follow npm `latest`, prerelease deployments follow npm `next`, and upgrade guidance requires only Node/npm.
+- [ ] The release workflow verifies the reviewed source, publishes the exact tarball, and creates a version-matched GitHub prerelease with release notes.
+- [ ] The complete rc.7 parity, 0.1.3 durable-state, package, and both-runtime installation evidence passes on the release candidate.
+
+Evidence: canonical root `ff2adbd74cf6fe9196460e234180a9f5310c4eee` has no parent and tree `ddb4f9b64b059851597fb6a31a1b29680d9cc908`, identical to archived PR 4. [Edge CI run 32385210909](https://github.com/pawaca/dsh-edge/actions/runs/32385210909) passed the clean repository's full verification. The remaining items are intentionally split between repository hygiene and alpha-readiness changes so neither PR hides a product or publication decision inside the source-extraction diff.
+
+### Stage 6 — Upgrade the published upstream baseline
+
+Objective: upgrade the standalone wrapper separately from source extraction and alpha.1 publication, after a newer coherent Harness package set is available.
+
+Scope: update every exact Harness dependency from `0.1.0-rc.7` to one selected published release; regenerate assembly inputs; retire obsolete patches; classify new plugins and visible changes; retain Edge branding and exclude unsupported capabilities.
+
+Excluded: unpublished source snapshots, piecemeal Dependabot bumps, deferred-plugin implementation, unrelated upstream defects, and persistence or authentication redesign.
 
 - [ ] Every Edge-relevant upstream change has an adopted, adapted, deferred, or excluded disposition.
+- [ ] All `@deepseek-ai/dsh-*` packages use one exact published baseline.
 - [ ] Patch count does not increase without an explicit amendment and rationale.
 - [ ] Removing a retained patch fails its regression test.
 - [ ] The parity matrix passes in both runtime modes.
 - [ ] UI manifests expose only capabilities supported by Edge.
 
-Evidence: pending.
+Evidence: pending. The npm registry still reports `0.1.0-rc.7` as the latest coherent published Harness baseline at the clean-root cutover, so this stage must not invent an `rc.8` source dependency.
 
-### PR 6 — Close distribution and installation
+### Stage 7 — Rehearse beta, rollback, and release 0.2
 
-Objective: install and upgrade the wrapper without cloning a repository or connecting a source repository.
+Objective: prove fresh installation, existing-instance upgrade, rollback, documentation, and publication before stable release.
 
-Scope: publish a self-contained `dsh-edge` package; verify its packed artifact; support both runtime modes in the installer; provide version and upgrade guidance; validate installation on macOS, Linux, and Windows; exercise temporary, free-account, and paid-account Cloudflare paths where account ownership permits.
-
-Excluded: commercial account management, GitHub source builds, and protected-page readiness polling.
-
-- [ ] A temporary directory installs and deploys using only the npm artifact.
-- [ ] The installed package has no repository-relative or Git submodule dependency.
-- [ ] Direct mode deploys on a free Cloudflare account.
-- [ ] Dynamic Loader deploys on an eligible paid account.
-- [ ] Secrets stay out of logs, committed configuration, and package artifacts.
-- [ ] CLI completion reports URL, credential handling, mode, next action, and upgrade command without speculative polling.
-
-Evidence: pending.
-
-### PR 7 — Rehearse upgrade and release 0.2
-
-Objective: prove fresh installation, existing-instance upgrade, rollback, documentation, and publication.
-
-Scope: deploy isolated canaries for both modes; rehearse a 0.1.3 durable-data upgrade and rollback; update English and Chinese user docs, compatibility information, and release notes; publish matching npm, tag, and GitHub Release versions after approval.
+Scope: validate temporary and claimed Free installs plus an eligible paid Dynamic Loader install; deploy isolated canaries for both modes; rehearse a 0.1.3 durable-data upgrade and rollback; update English and Chinese compatibility information and release notes; publish matching beta and stable npm, tag, and GitHub Release versions after approval.
 
 Excluded: attachment, export, remote MCP, Skills, Workflows, Jobs, and commercial authentication.
 
-- [ ] Fresh installation passes in both modes.
-- [ ] A 0.1.3 canary upgrades without losing session, message, VFS, settings, or authentication state.
+- [ ] A temporary directory installs using only the npm artifact, without a repository or source-build integration.
+- [ ] Direct mode installs on the anonymous or claimed Free path and Dynamic Loader installs on an eligible paid account.
+- [ ] A 0.1.3 canary upgrades without losing session, message, VFS, settings, authentication state, or deployment identity.
 - [ ] The documented rollback is executed against a canary.
+- [ ] Secrets stay out of logs, committed configuration, package artifacts, and durable state.
 - [ ] No launch-scope P0 or P1 defect remains.
-- [ ] Public documentation requires no upstream-monorepo knowledge.
-- [ ] npm, Git tag, GitHub Release, release notes, and artifact agree on `0.2.0`.
+- [ ] npm, Git tag, GitHub Release, release notes, and deployed health agree first on `0.2.0-beta.1` and then on `0.2.0`.
 
 Evidence: pending.
 
 ### Parity matrix
 
-PRs may add discovered existing behavior. Removing or weakening a row requires a Change log amendment.
+Stages may add discovered existing behavior. Removing or weakening a row requires a Change log amendment.
 
 | User path | Direct | Dynamic Loader | Evidence |
 | --- | --- | --- | --- |
@@ -198,7 +201,7 @@ PRs may add discovered existing behavior. Removing or weakening a row requires a
 - 2026-08-19: Created this plan on Edge 0.1.3 and Harness `0.1.0-rc.7`. PR 1 entered `in progress`; no acceptance criterion was amended.
 - 2026-08-19: Added the 0.1.3 SQL fixture, explicit VFS restart assertion, build-size evidence, and complete grouped disposition of current non-Edge fork changes. Five PR 1 criteria are satisfied; full Edge CI remains pending.
 - 2026-08-19: Local unit, integration, browser snapshot, typecheck, documentation, lint, both Worker builds, pack, and installed-package checks passed. PR 1 entered `in review`; the remaining criterion waits for hosted Edge CI.
-- 2026-08-19: Opened [PR #25](https://github.com/pawaca/dsh-edge/pull/25) as a draft. Hosted CI and the HEAD-bound review loop are now the remaining gates.
+- 2026-08-19: Opened archived [PR #25](https://github.com/pawaca/dsh-edge-history/pull/25) as a draft. Hosted CI and the HEAD-bound review loop are now the remaining gates.
 - 2026-08-19: Review found that candidate-created restart state did not prove upgrade compatibility. Added immutable 0.1.3 VFS state plus read-write-reload coverage for both VFS and session persistence; the PR contract did not change.
 - 2026-08-19: Follow-up review found invalid parent-child insertion order in the VFS fixture. Reordered the rows and added an explicit foreign-key integrity check; the full integration passed.
 - 2026-08-19: Follow-up review found untranslated headings in the Chinese Agent Note. Translated the complete heading hierarchy and re-recorded the bilingual pair; the PR contract did not change.
@@ -208,13 +211,14 @@ PRs may add discovered existing behavior. Removing or weakening a row requires a
 - 2026-08-20: PR 1 merged after hosted Edge CI and HEAD-bound review passed. PR 2 entered `in progress`; its scope and acceptance criteria remain unchanged.
 - 2026-08-20: PR 2 gained the exact rc.7 dependency closure, published Web and Cordis assembly, six version-coupled package patches, Edge-client-only build, both standalone Worker modes, dependency-origin enforcement, and parallel CI. Local build, parity, unit, typecheck, and lint evidence passed; clean-clone hosted CI remains pending.
 - 2026-08-20: PR 2 isolated all parallel-path tools beneath `apps/dsh-edge/standalone`, leaving the released package command surface and tarball unchanged. A rebuilt 0.1.3 tarball passed external installation and Direct-runtime smoke verification and contained no standalone-only file.
-- 2026-08-20: Opened [PR #26](https://github.com/pawaca/dsh-edge/pull/26) for PR 2. The clean-clone hosted CI and HEAD-bound review are now the remaining acceptance gates.
+- 2026-08-20: Opened archived [PR #26](https://github.com/pawaca/dsh-edge-history/pull/26) for PR 2. The clean-clone hosted CI and HEAD-bound review are now the remaining acceptance gates.
 - 2026-08-20: Review found that importing the production Wrangler helper let the root install supply `jsonc-parser`, masking a missing standalone dependency. Split out a dependency-free rendering core, made standalone parse through its own exact dependency, and ordered hosted CI to build standalone before the root install; the PR contract did not change.
 - 2026-08-20: PR 2 merged after its clean-clone CI and HEAD-bound review passed. PR 3 entered `in progress` to switch development, packaging, and deployment authority to the rc.7 standalone path without deleting fork source or upgrading upstream.
 - 2026-08-20: PR 3 routed build, dev, CI, prepack, release, and installer preparation through standalone artifacts while retaining the existing package layout. Both promoted runtime modes passed the full 0.1.3 compatibility suite. A deterministic-build check was added after Lightning CSS export iteration exposed unstable class-map property order; sorting those keys removed byte and cache-revision drift without changing runtime semantics.
-- 2026-08-20: PR 3 passed hosted CI and HEAD-bound review, then merged as [PR #27](https://github.com/pawaca/dsh-edge/pull/27). PR 4 entered `in progress`; it retains the two Edge-owned workspaces while replacing every remaining upstream workspace dependency, source-only check, workflow, and governance document with an Edge-owned equivalent.
+- 2026-08-20: PR 3 passed hosted CI and HEAD-bound review, then merged as archived [PR #27](https://github.com/pawaca/dsh-edge-history/pull/27). PR 4 entered `in progress`; it retains the two Edge-owned workspaces while replacing every remaining upstream workspace dependency, source-only check, workflow, and governance document with an Edge-owned equivalent.
 - 2026-08-20: PR 4 removed the copied Harness source and upstream-wide governance, reduced the repository to two Edge-owned workspaces and two workflows, replaced source-mode tests and publication machinery with Edge-owned contracts, and passed clean standalone, unit, integration, snapshot, packaging, legal, lint, and type checks. A clean build exposed checkout-path-dependent CSS Module hashes; the Edge client build now uses a stable repository-relative CSS identity, and a verifier plus two-path byte comparison close that reproducibility gap without changing product behavior.
-- 2026-08-20: Opened draft [PR #28](https://github.com/pawaca/dsh-edge/pull/28) for PR 4 after local acceptance passed. Hosted clean-checkout CI and the HEAD-bound review loop are now the remaining gates.
+- 2026-08-20: Opened draft archived [PR #28](https://github.com/pawaca/dsh-edge-history/pull/28) for PR 4 after local acceptance passed. Hosted clean-checkout CI and the HEAD-bound review loop are now the remaining gates.
+- 2026-08-20: Archived PR 4 passed hosted CI and the HEAD-bound review loop, then merged. Its reviewed tree became the single root commit of the new standalone [canonical repository](https://github.com/pawaca/dsh-edge); the former fork moved intact to [dsh-edge-history](https://github.com/pawaca/dsh-edge-history). The clean-root Edge CI passed, Stage 5 entered `in progress`, and alpha.1 moved behind explicit repository-hygiene and release-contract gates instead of being implied by source deletion.
 
 ## Alternatives considered
 
@@ -230,7 +234,7 @@ PRs may add discovered existing behavior. Removing or weakening a row requires a
 
 ## Acceptance criteria
 
-- All seven PRs are merged with checked criteria and recorded evidence.
+- All seven stages are complete with checked criteria and recorded evidence.
 - The repository builds from exact upstream packages and contains no copied Harness source.
 - Both runtime modes preserve the parity matrix and released durable data.
 - The package installs without a repository clone and publishes matching npm, tag, and GitHub Release versions.
@@ -238,10 +242,10 @@ PRs may add discovered existing behavior. Removing or weakening a row requires a
 
 ## Risks
 
-Published packages may omit manifests or Web assets currently read from source. PR 2 must discover this before cutover; a missing artifact warrants an upstream packaging request or narrow adapter input, not a monorepo copy.
+Published packages may omit manifests or Web assets required by the assembly. The standalone verifier must discover this before adopting a baseline; a missing artifact warrants an upstream packaging request or narrow adapter input, not a monorepo copy.
 
-Cloudflare size and loader behavior may differ between dry runs and real accounts. Build evidence does not replace PR 6 and PR 7 account validation.
+Cloudflare size and loader behavior may differ between dry runs and real accounts. Build evidence does not replace Stage 7 account validation.
 
 Logical storage compatibility does not prevent accidental binding or class-name changes. Fixtures, configuration assertions, and canary rehearsal protect separate risks and all remain required.
 
-Governance cleanup can remove a useful check accidentally. PR 4 deletes by responsibility, not file count, and proves a replacement for every retained Edge risk.
+Governance cleanup can remove a useful check accidentally. Stage 5 audits the clean-root repository against the retained Edge risks before alpha publication.

--- a/.agents/notes/proposed/architecture/2026-08-19-dsh-edge-standalone-wrapper.zh.md
+++ b/.agents/notes/proposed/architecture/2026-08-19-dsh-edge-standalone-wrapper.zh.md
@@ -6,7 +6,7 @@ Status: proposed
 
 ## 问题
 
-DSH Edge 目前以 DeepSeek Harness 源码 fork 的方式维护，但产品自己负责的实现只包括 Cloudflare runtime、安装器、Edge client plugin、部署模式和少量上游适配。这个 fork 同时携带无关的上游源码、研发规范、CI、发布体系和文档工具，使上游更新表现为整仓合并，也让 DSH Edge 的所有权边界不清晰。
+DSH Edge 最初以 DeepSeek Harness 源码 fork 的方式维护，但产品自己负责的实现只包括 Cloudflare runtime、安装器、Edge client plugin、部署模式和少量上游适配。这个 fork 同时携带了无关的上游源码、研发规范、CI、发布体系和文档工具，使上游更新表现为整仓合并，也让 DSH Edge 的所有权边界不清晰。
 
 0.2 版本需要依赖精确版本的 Harness 发布包，在不复制上游仓库的情况下装配应用，并且只保留无法通过公开扩展点实现的 patch。迁移必须保留已经发布的 0.1.3 行为和持久化数据，同时保证每个合入 `master` 的版本都可以构建、部署和发布。
 
@@ -29,17 +29,17 @@ standalone 仓库负责 Cloudflare Worker、Direct 和 Dynamic Loader runtime、
 
 ### 进度约定
 
-每个 PR 只有一种状态：`planned`、`in progress`、`in review`、`merged` 或 `blocked`。只有在 Evidence 字段写明命令、产物、测试或部署证据后，验收项才能勾选。范围或验收标准变化必须附理由追加到 Change log，不能静默降低标准。
+每个阶段只有一种状态：`planned`、`in progress`、`in review`、`merged` 或 `blocked`。只有在 Evidence 字段写明命令、产物、测试或部署证据后，验收项才能勾选。范围或验收标准变化必须附理由追加到 Change log，不能静默降低标准。阶段 1 至阶段 4 是原始迁移序列，对应的 GitHub 工作已作为 PR 25 至 PR 28 归档；阶段 5 至阶段 7 描述 clean-root 切换后的发布路线，不代表新仓库中的 PR 编号。
 
-| PR | 目标 | 状态 | 版本 | 用户操作 |
+| 阶段 | 目标 | 状态 | 版本 | 用户操作 |
 | --- | --- | --- | --- | --- |
-| 1 | 冻结 0.1.3 基线 | merged | 无 | 无；[PR #25](https://github.com/pawaca/dsh-edge/pull/25) 已合并 |
-| 2 | 增加并行 standalone 装配路径 | merged | 无 | 无；[PR #26](https://github.com/pawaca/dsh-edge/pull/26) 已合并 |
-| 3 | 达到 rc.7 等价后切换 | merged | 无 | 无；[PR #27](https://github.com/pawaca/dsh-edge/pull/27) 已合并 |
-| 4 | 删除 fork 源码并简化规范 | in review | `0.2.0-alpha.1` | 批准预发布；[PR #28](https://github.com/pawaca/dsh-edge/pull/28) 已创建 |
-| 5 | 升级精确上游基线 | planned | `0.2.0-alpha.2` | 批准预发布 |
-| 6 | 打通分发和安装 | planned | `0.2.0-beta.1` | 完成账号所有者才能执行的 Cloudflare 流程；批准 beta |
-| 7 | 演练升级并发布 0.2 | planned | `0.2.0` | 批准生产替换和发布 |
+| 1 | 冻结 0.1.3 基线 | merged | 无 | 无；归档的 [PR #25](https://github.com/pawaca/dsh-edge-history/pull/25) 已合并 |
+| 2 | 增加并行 standalone 装配路径 | merged | 无 | 无；归档的 [PR #26](https://github.com/pawaca/dsh-edge-history/pull/26) 已合并 |
+| 3 | 达到 rc.7 等价后切换 | merged | 无 | 无；归档的 [PR #27](https://github.com/pawaca/dsh-edge-history/pull/27) 已合并 |
+| 4 | 删除 fork 源码并简化规范 | merged | 无 | 无；归档的 [PR #28](https://github.com/pawaca/dsh-edge-history/pull/28) 已合并 |
+| 5 | 完成切换后卫生收尾并发布 rc.7 standalone 基线 | in progress | `0.2.0-alpha.1` | 仓库与发布门禁通过后批准预发布 |
+| 6 | 在新的完整 package 集合发布后升级精确上游基线 | planned | `0.2.0-alpha.2` | 批准预发布 |
+| 7 | 演练 canary 升级、beta、回滚并发布 0.2 | planned | `0.2.0-beta.1`，然后 `0.2.0` | 完成账号所有者才能执行的 Cloudflare 流程；批准 beta 和稳定版发布 |
 
 ### PR 1 — 冻结 0.1.3 基线
 
@@ -56,7 +56,7 @@ standalone 仓库负责 Cloudflare Worker、Direct 和 Dynamic Loader runtime、
 - [x] 每项非 Edge fork 修改都归类为 adapter、保留 patch、上游候选或删除项。
 - [x] Evidence 写明精确命令和产物。
 
-Evidence：`dsh-edge-0.1.3-session.sql` 固定已发布 SQL schema、一个完整 turn 和一个 blank session。适配器测试会恢复 canonical session 并继续追加事件，把 blank session 提升后写入，然后重新加载两者。`dsh-edge-0.1.3-vfs.sql` 固定已发布 `@cloudflare/computer` 0.2.0 schema 和内容，`dsh-edge-0.1.3-workspace.json` 则固定已发布 workspace 的标题、session 排序和归档状态。仅用于测试的 Durable Object seeder 会通过原生 SQL 和 KV storage 写入三份 fixture，再拒绝任何外键完整性错误，然后才启动候选 Worker。Miniflare integration 随后读取并扩展已发布 VFS，要求第一次续写重建两条已发布消息，通过生产 Worker API 提升并持久化已发布 blank session，并通过 RPC 读取、重命名、附加和重新加载已发布 workspace。现有 settings、preset、session、Web Search、HTTP 和 WebSocket snapshot 继续作为 UI 与协议 fixture。Persistence test 的 23 项测试通过，完整 session integration 通过，browser snapshot suite 的 3 项测试通过。`pnpm --filter dsh-edge run bundle:workers` 报告 Direct gzip 为 683,920 bytes，低于仓库 921,600-byte budget；Dynamic Loader gzip 为 959.59 KiB。Hosted [Edge CI run 32343433389](https://github.com/pawaca/dsh-edge/actions/runs/32343433389) 在已 Review 的 head 上通过，[PR #25](https://github.com/pawaca/dsh-edge/pull/25) 以 `b1627b0fd033b2efdcd1a5b09e4b3160b74a1e1c` 合并。
+Evidence：`dsh-edge-0.1.3-session.sql` 固定已发布 SQL schema、一个完整 turn 和一个 blank session。适配器测试会恢复 canonical session 并继续追加事件，把 blank session 提升后写入，然后重新加载两者。`dsh-edge-0.1.3-vfs.sql` 固定已发布 `@cloudflare/computer` 0.2.0 schema 和内容，`dsh-edge-0.1.3-workspace.json` 则固定已发布 workspace 的标题、session 排序和归档状态。仅用于测试的 Durable Object seeder 会通过原生 SQL 和 KV storage 写入三份 fixture，再拒绝任何外键完整性错误，然后才启动候选 Worker。Miniflare integration 随后读取并扩展已发布 VFS，要求第一次续写重建两条已发布消息，通过生产 Worker API 提升并持久化已发布 blank session，并通过 RPC 读取、重命名、附加和重新加载已发布 workspace。现有 settings、preset、session、Web Search、HTTP 和 WebSocket snapshot 继续作为 UI 与协议 fixture。Persistence test 的 23 项测试通过，完整 session integration 通过，browser snapshot suite 的 3 项测试通过。`pnpm --filter dsh-edge run bundle:workers` 报告 Direct gzip 为 683,920 bytes，低于仓库 921,600-byte budget；Dynamic Loader gzip 为 959.59 KiB。Hosted [Edge CI run 32343433389](https://github.com/pawaca/dsh-edge-history/actions/runs/32343433389) 在已 Review 的 head 上通过，归档的 [PR #25](https://github.com/pawaca/dsh-edge-history/pull/25) 以 `b1627b0fd033b2efdcd1a5b09e4b3160b74a1e1c` 合并。
 
 `apps/dsh-edge/**` 和 `packages/client/ui-edge/**` 之外的当前 fork 修改按以下方式处理：
 
@@ -125,59 +125,62 @@ Evidence：`pnpm --filter dsh-edge run bundle:workers` 现在只从隔离的 rc.
 
 Evidence：一个没有父级或根依赖的临时 checkout 在安装根依赖以前完成了 standalone frozen install、两种 Worker 构建、确定性 Web 重建、6 个 patch 和 28 个 client plugin 验证。同一份 Edge client 源码随后在两个绝对路径不同的 checkout 中生成了字节完全相同的 client bundle（`37f005f9b979d20cd2f1ca08306ee8bd760b618d7bd106287a990d4c293cfc23`）；验证器会拒绝 release 产物中的绝对 checkout 路径。Direct gzip 为 686,060 bytes，低于 921,600-byte budget，Dynamic Loader 为 961.63 KiB。根测试的 20 个文件、176 项测试全部通过，两种模式通过完整 release-artifact integration，3 个 assembled-runtime/browser/installer snapshot 通过，Edge typecheck 和 type-aware lint 通过。全新的 `dsh-edge-0.1.3.tgz` 在 workspace 外安装并启动两种预构建模式，内容仅有 release Web assets、Workers、installer/runtime scripts、双语 package 文档和法律声明。仓库现在只有 `apps/dsh-edge` 和 `packages/client/ui-edge` 两个源码 workspace；CI 只剩 `edge-ci.yml` 和 `release-edge.yml`；根法律文件把 dsh-edge 归属于 pawaca，同时保留 DeepSeek 上游 MIT 声明；根 `AGENTS.md` 维护项目规则，真实的根 `CLAUDE.md` 将 Claude Code 指向这些规则。
 
-### PR 5 — 升级上游基线
+### 阶段 5 — 完成切换后卫生收尾并发布 alpha.1
 
-目标：将 standalone wrapper 升级上游版本，不与源码抽取混在一起。
+目标：把 clean-root 仓库确立为可信的 canonical source，然后把行为保持不变的 rc.7 standalone 基线发布为 `0.2.0-alpha.1`。
 
-范围：把精确依赖从 `0.1.0-rc.7` 升级到选定版本，初始目标为 `0.1.0-rc.8`；重新生成装配输入；移除过时 patch；分类上游新增 plugin 和可见变化；保留 Edge 品牌并排除尚未支持的能力。
+范围：保留已归档的开发记录；修复仓库、安全、依赖自动化与双语文档卫生；让预发布更新发现感知发布通道；要求 tag 指向已 Review 的 `master`；npm 发布成功后才创建匹配的 GitHub prerelease；发布前重新执行 packed artifact 与等价性证据。
 
-不在范围内：实现暂缓插件、解决无关上游缺陷，以及重新设计持久化或认证。
+不在范围内：升级上游依赖、实现暂缓插件、改变 runtime 行为和商业账号管理。
+
+- [x] Canonical 仓库不是 fork，只有一个 clean root commit，并且 tree 与已 Review 的 PR 4 完全一致。
+- [x] 归档仓库保留 PR 25 至 PR 28、对应 Review 历史和 0.1.3 GitHub Release。
+- [ ] 面向用户和贡献者的文档正确说明归档地址、当前安全报告入口与受支持安装命令，不包含过时链接。
+- [ ] 依赖自动化不会把 root、standalone、法律声明和 snapshot 的协同不变量拆成误导性的绿色 PR 或永久失败 PR。
+- [ ] 稳定部署跟随 npm `latest`，预发布部署跟随 npm `next`，升级指引只要求 Node/npm。
+- [ ] 发布 workflow 验证已 Review 的源码、发布精确 tarball，并创建版本匹配且包含 release notes 的 GitHub prerelease。
+- [ ] 完整 rc.7 等价性、0.1.3 持久化状态、package 与两种 runtime 安装证据在 release candidate 上通过。
+
+Evidence：canonical root `ff2adbd74cf6fe9196460e234180a9f5310c4eee` 没有 parent，tree 为 `ddb4f9b64b059851597fb6a31a1b29680d9cc908`，与归档的 PR 4 一致。[Edge CI run 32385210909](https://github.com/pawaca/dsh-edge/actions/runs/32385210909) 通过 clean repository 的完整验证。剩余工作有意拆成仓库卫生和 alpha readiness 两类修改，避免任何 PR 把产品或发布决策藏在源码抽取 diff 中。
+
+### 阶段 6 — 升级已发布的上游基线
+
+目标：在源码抽取和 alpha.1 发布之外，单独升级 standalone wrapper 的上游版本，并且只在出现更新且完整的 Harness package 集合后执行。
+
+范围：把所有精确 Harness 依赖从 `0.1.0-rc.7` 升级到一个选定的已发布版本；重新生成装配输入；移除过时 patch；分类新增 plugin 和可见变化；保留 Edge 品牌并排除尚未支持的能力。
+
+不在范围内：未发布源码快照、拆散的 Dependabot bump、实现暂缓插件、解决无关上游缺陷，以及重新设计持久化或认证。
 
 - [ ] 每项与 Edge 相关的上游变化都归类为采用、适配、暂缓或排除。
+- [ ] 所有 `@deepseek-ai/dsh-*` package 使用同一个精确的已发布基线。
 - [ ] 未经明确修订和说明理由，patch 数量不得增加。
 - [ ] 移除任一保留 patch 时，对应回归测试会失败。
 - [ ] 等价矩阵在两种 runtime 模式通过。
 - [ ] UI manifest 只暴露 Edge 支持的能力。
 
-Evidence：待补充。
+Evidence：待补充。Clean-root 切换时，npm registry 仍把 `0.1.0-rc.7` 报告为最新的完整 Harness 发布基线，因此本阶段不能凭空引入 `rc.8` 源码依赖。
 
-### PR 6 — 完成分发与安装闭环
+### 阶段 7 — 演练 beta、回滚并发布 0.2
 
-目标：无需 clone 仓库或连接 source repo 即可安装和升级 wrapper。
+目标：在稳定版发布前证明全新安装、已有实例升级、回滚、文档和发布流程。
 
-范围：发布自包含 `dsh-edge` package；验证 packed artifact；安装器支持两种 runtime 模式；提供版本和升级引导；验证 macOS、Linux 和 Windows 安装；在账号所有权允许的范围内验证 Cloudflare 临时、免费账号和付费账号路径。
-
-不在范围内：商业账号管理、GitHub source build 和受保护页面 readiness polling。
-
-- [ ] 临时目录只使用 npm artifact 即可完成安装和部署。
-- [ ] 安装后的 package 不依赖仓库相对路径或 Git submodule。
-- [ ] Direct 模式可以部署到 Cloudflare 免费账号。
-- [ ] Dynamic Loader 可以部署到符合条件的付费账号。
-- [ ] secret 不会进入日志、已提交配置或 package artifact。
-- [ ] CLI 完成信息准确说明 URL、credential 处理、模式、下一步和升级命令，不进行推测性 polling。
-
-Evidence：待补充。
-
-### PR 7 — 演练升级并发布 0.2
-
-目标：证明全新安装、已有实例升级、回滚、文档和发布流程。
-
-范围：为两种模式部署隔离 canary；演练 0.1.3 持久化数据升级和回滚；更新中英文用户文档、兼容信息和 release notes；获批后发布版本一致的 npm、tag 和 GitHub Release。
+范围：验证临时与已认领的 Free 安装，以及符合资格的付费 Dynamic Loader 安装；为两种模式部署隔离 canary；演练 0.1.3 持久化数据升级和回滚；更新中英文兼容信息与 release notes；获批后发布版本一致的 beta 与稳定版 npm、tag 和 GitHub Release。
 
 不在范围内：attachment、export、remote MCP、Skills、Workflows、Jobs 和商业认证。
 
-- [ ] 全新安装在两种模式通过。
-- [ ] 0.1.3 canary 升级后不丢失 session、消息、VFS、settings 或认证状态。
+- [ ] 临时目录只使用 npm artifact 即可完成安装，不需要仓库或 source-build 集成。
+- [ ] Direct 模式通过匿名或已认领的 Free 路径安装，Dynamic Loader 在符合资格的付费账号中安装。
+- [ ] 0.1.3 canary 升级后不丢失 session、消息、VFS、settings、认证状态或 deployment identity。
 - [ ] 在 canary 上执行文档中的回滚流程。
+- [ ] secret 不会进入日志、已提交配置、package artifact 或持久化状态。
 - [ ] 上线范围内不存在 P0 或 P1 缺陷。
-- [ ] 公开文档不要求了解上游 monorepo。
-- [ ] npm、Git tag、GitHub Release、release notes 和 artifact 的版本均为 `0.2.0`。
+- [ ] npm、Git tag、GitHub Release、release notes 和 deployed health 先在 `0.2.0-beta.1` 上一致，再在 `0.2.0` 上一致。
 
 Evidence：待补充。
 
 ### 等价矩阵
 
-PR 可以增加后来发现的现有行为。删除或降低某一行要求必须在 Change log 中修订。
+阶段可以增加后来发现的现有行为。删除或降低某一行要求必须在 Change log 中修订。
 
 | 用户路径 | Direct | Dynamic Loader | 证据 |
 | --- | --- | --- | --- |
@@ -198,7 +201,7 @@ PR 可以增加后来发现的现有行为。删除或降低某一行要求必�
 - 2026-08-19：在 Edge 0.1.3 和 Harness `0.1.0-rc.7` 基线上创建本计划。PR 1 进入 `in progress`，没有修订验收标准。
 - 2026-08-19：增加 0.1.3 SQL fixture、明确的 VFS 重启 assertion、构建体积证据和当前非 Edge fork 修改的完整分组结论。PR 1 已满足五项标准，完整 Edge CI 仍待执行。
 - 2026-08-19：本地 unit、integration、browser snapshot、typecheck、documentation、lint、两种 Worker build、pack 和 installed-package check 均通过。PR 1 进入 `in review`；剩余标准等待 hosted Edge CI。
-- 2026-08-19：已将 [PR #25](https://github.com/pawaca/dsh-edge/pull/25) 作为 draft 打开。当前剩余门槛是 hosted CI 和绑定 HEAD 的 review loop。
+- 2026-08-19：已将归档的 [PR #25](https://github.com/pawaca/dsh-edge-history/pull/25) 作为 draft 打开。当前剩余门槛是 hosted CI 和绑定 HEAD 的 review loop。
 - 2026-08-19：Review 指出由候选版本自身创建的重启状态不能证明升级兼容性。现已增加不可变的 0.1.3 VFS 状态，并为 VFS 和 session persistence 补齐读取、续写、重新加载覆盖；PR contract 没有变化。
 - 2026-08-19：后续 Review 指出 VFS fixture 中 parent-child 插入顺序无效。现已调整行顺序并增加显式 foreign-key integrity check；完整 integration 已通过。
 - 2026-08-19：后续 Review 指出中文 Agent Note 的标题仍为英文。现已按术语规范翻译完整标题层级并重新记录双语配对；PR contract 没有变化。
@@ -208,13 +211,14 @@ PR 可以增加后来发现的现有行为。删除或降低某一行要求必�
 - 2026-08-20：PR 1 在 hosted Edge CI 和 HEAD-bound review 通过后合并。PR 2 进入 `in progress`；范围和验收标准保持不变。
 - 2026-08-20：PR 2 已加入精确固定的 rc.7 依赖闭包、发布版 Web 与 Cordis 装配、6 个绑定版本的 package patch、只构建 Edge client 的路径、两种 standalone Worker 模式、依赖来源强制检查以及并行 CI。本地 build、等价性、unit、typecheck 和 lint 证据均已通过；全新 clone 的 hosted CI 仍待执行。
 - 2026-08-20：PR 2 已把所有并行路径工具隔离到 `apps/dsh-edge/standalone` 下，保持已发布 package 的命令面和 tarball 不变。重新构建的 0.1.3 tarball 已通过外部安装与 Direct runtime smoke 验证，且不包含任何 standalone 专用文件。
-- 2026-08-20：已为 PR 2 创建 [PR #26](https://github.com/pawaca/dsh-edge/pull/26)。当前剩余验收门槛是全新 clone 的 hosted CI 和绑定 HEAD 的 review。
+- 2026-08-20：已为 PR 2 创建归档的 [PR #26](https://github.com/pawaca/dsh-edge-history/pull/26)。当前剩余验收门槛是全新 clone 的 hosted CI 和绑定 HEAD 的 review。
 - 2026-08-20：Review 指出，导入生产 Wrangler helper 会让根安装提供 `jsonc-parser`，掩盖 standalone 缺失的依赖。现已拆出无第三方依赖的渲染 core，让 standalone 使用自身精确依赖完成解析，并调整 hosted CI 顺序，使 standalone 在根安装前构建；PR contract 没有变化。
 - 2026-08-20：PR 2 在全新 clone 的 CI 与绑定 HEAD 的 review 通过后合并。PR 3 进入 `in progress`，将在不删除 fork 源码、不升级上游的前提下，把开发、打包和部署的权威路径切换到 rc.7 standalone 路径。
 - 2026-08-20：PR 3 已把 build、dev、CI、prepack、release 和 installer preparation 路由到 standalone 产物，同时保留现有 package 布局。两种已提升 runtime 模式均通过完整 0.1.3 兼容测试。Lightning CSS export 迭代暴露 class-map 属性顺序不稳定后，增加了确定性构建检查；对 key 排序消除了字节和缓存 rev 漂移，没有改变 runtime 语义。
-- 2026-08-20：PR 3 通过 hosted CI 与绑定 HEAD 的 review 后，以 [PR #27](https://github.com/pawaca/dsh-edge/pull/27) 合并。PR 4 进入 `in progress`；它保留两个 Edge 自有 workspace，并把剩余的上游 workspace 依赖、仅源码检查、workflow 和治理文档全部替换为 Edge 自有实现。
+- 2026-08-20：PR 3 通过 hosted CI 与绑定 HEAD 的 review 后，以归档的 [PR #27](https://github.com/pawaca/dsh-edge-history/pull/27) 合并。PR 4 进入 `in progress`；它保留两个 Edge 自有 workspace，并把剩余的上游 workspace 依赖、仅源码检查、workflow 和治理文档全部替换为 Edge 自有实现。
 - 2026-08-20：PR 4 删除了复制的 Harness 源码和面向整个上游的治理规范，把仓库缩减为两个 Edge 自有 workspace 和两个 workflow，以 Edge 自有 contract 代替 source-mode 测试和发布机制，并通过全新 standalone、单元、集成、snapshot、打包、法律、lint 和类型检查。全新构建暴露出 CSS Module hash 依赖 checkout 路径；Edge client 构建现在使用稳定的仓库相对 CSS 身份，并以验证器和双路径字节对比关闭这个可复现性缺口，不改变产品行为。
-- 2026-08-20：PR 4 在本地验收通过后创建了 draft [PR #28](https://github.com/pawaca/dsh-edge/pull/28)。Hosted clean-checkout CI 和绑定 HEAD 的 review loop 是当前剩余门禁。
+- 2026-08-20：PR 4 在本地验收通过后创建了 draft、现已归档的 [PR #28](https://github.com/pawaca/dsh-edge-history/pull/28)。Hosted clean-checkout CI 和绑定 HEAD 的 review loop 是当前剩余门禁。
+- 2026-08-20：归档的 PR 4 通过 hosted CI 和绑定 HEAD 的 review loop 后合并。其已 Review 的 tree 成为新的独立 [canonical repository](https://github.com/pawaca/dsh-edge) 的唯一 root commit，原 fork 则完整迁移到 [dsh-edge-history](https://github.com/pawaca/dsh-edge-history)。Clean-root Edge CI 通过，阶段 5 进入 `in progress`；alpha.1 现在受明确的仓库卫生与发布 contract 门禁约束，不再由删除源码这件事隐式触发。
 
 ## 已考虑的替代方案
 
@@ -230,7 +234,7 @@ PR 可以增加后来发现的现有行为。删除或降低某一行要求必�
 
 ## 验收标准
 
-- 七个 PR 均已合并，各项验收已勾选并记录证据。
+- 七个阶段均已完成，各项验收已勾选并记录证据。
 - 仓库从精确版本的上游 package 构建，并且不包含 Harness 源码副本。
 - 两种 runtime 模式保持等价矩阵和已发布持久化数据。
 - package 无需 clone 仓库即可安装，并发布版本一致的 npm、tag 和 GitHub Release。
@@ -238,10 +242,10 @@ PR 可以增加后来发现的现有行为。删除或降低某一行要求必�
 
 ## 风险
 
-上游发布包可能没有包含当前从源码读取的 manifest 或 Web asset。PR 2 必须在切换以前发现这种缺口；缺少产物意味着提出上游打包要求或使用范围严格的 adapter 输入，而不是复制 monorepo。
+上游发布包可能缺少装配所需的 manifest 或 Web asset。Standalone verifier 必须在采用基线以前发现这种缺口；缺少产物意味着提出上游打包要求或使用范围严格的 adapter 输入，而不是复制 monorepo。
 
-Cloudflare 体积和 loader 行为可能在 dry run 与真实账号之间存在差异。构建证据不能替代 PR 6 和 PR 7 的账号验证。
+Cloudflare 体积和 loader 行为可能在 dry run 与真实账号之间存在差异。构建证据不能替代阶段 7 的账号验证。
 
 逻辑存储兼容不能防止 binding 或 class 名称意外变化。fixture、配置 assertion 和 canary 演练保护不同风险，三者都必须完成。
 
-规范精简可能误删有价值的检查。PR 4 按责任而不是文件数量删除内容，并且为每项保留的 Edge 风险证明替代保护。
+规范精简可能误删有价值的检查。阶段 5 会在 alpha 发布前根据保留的 Edge 风险审计 clean-root 仓库。

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,18 +1,9 @@
 version: 2
 
 updates:
-  - package-ecosystem: npm
-    directory: /
-    schedule:
-      interval: weekly
-    labels: [dependencies]
-
-  - package-ecosystem: npm
-    directory: /apps/dsh-edge/standalone
-    schedule:
-      interval: weekly
-    labels: [dependencies, upstream]
-
+  # Root and standalone dependency versions, generated legal notices, and
+  # snapshots are coordinated. Update them together in an explicit dependency
+  # or upstream-baseline PR instead of opening independent npm PRs.
   - package-ecosystem: github-actions
     directory: /
     schedule:

--- a/CONTRIBUTING.i18n.yaml
+++ b/CONTRIBUTING.i18n.yaml
@@ -2,5 +2,5 @@
 # last confirmed-consistent state. Both languages carry equal authority.
 # After editing either side, update both and re-record every pair with:
 #   pnpm run doc-pairs -- --write
-CONTRIBUTING.md: af1e60ea3d0d70f0a39f0e914199e6b0b787cd73
-CONTRIBUTING.zh.md: e9eeae58181fefbb9ed324074aa557419097d898
+CONTRIBUTING.md: 9b88425c8e1bbb659dfa0f414821f8f37b145660
+CONTRIBUTING.zh.md: 7f8c9be751bf7921243760b5927d0bd478b30bf6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,4 +12,4 @@ Before opening a pull request:
 4. Run `pnpm run check` and the focused standalone, integration, snapshot, or package checks required by the changed surface.
 5. Explain the user impact, validation, and any retained upstream patch in the pull request.
 
-Report security-sensitive issues privately to the maintainer rather than including secrets or exploit details in a public issue.
+Report security-sensitive issues through the [private security process](SECURITY.md), never through a public Issue or Discussion.

--- a/CONTRIBUTING.zh.md
+++ b/CONTRIBUTING.zh.md
@@ -12,4 +12,4 @@
 4. 运行 `pnpm run check`，并根据修改范围执行 standalone、integration、snapshot 或 package 的针对性检查。
 5. 在 Pull Request 中说明用户影响、验证证据和任何保留的上游 patch。
 
-安全敏感问题请私下联系维护者，不要在公开 Issue 中包含 secret 或可直接利用的细节。
+安全敏感问题请通过[私密安全流程](SECURITY.zh.md)报告，不要使用公开 Issue 或 Discussion。

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Durable Object data is retained. The installer asks for the owner access key and
 
 ## Current scope
 
-`dsh-edge` is a developer preview. The first public version focuses on a complete personal-use path: upstream conversations and workspaces, persistent sessions, model selection, Web Search, workspace file operations, command execution, and the upstream browser experience.
+`dsh-edge` is a developer preview. The current preview focuses on a complete personal-use path: upstream conversations and workspaces, persistent sessions, model selection, Web Search, workspace file operations, command execution, and the upstream browser experience.
 
 The deployment is deliberately single-owner. It does not provide registration, multiple users, roles, or tenant routing. Attachments and images, remote MCP, Skills, Workflows, Jobs, and Subagents are not yet adapted to the Edge runtime. `web_fetch` remains disabled until the runtime has an explicit policy for SSRF, private addresses, and redirects.
 
@@ -81,6 +81,8 @@ This repository is a standalone wrapper around exact published DeepSeek Harness 
 The isolated assembly under `apps/dsh-edge/standalone` pins one upstream version and records every unavoidable package patch. An upstream-defined schema or service contract remains unchanged unless the Edge environment makes that impossible.
 
 For upstream architecture and plugin development, use the [DeepSeek Harness repository](https://github.com/deepseek-ai/deepseek-harness) and [reference documentation](https://deepseek-harness.github.io/deepseek-harness/reference/).
+
+Development history before the standalone repository cutover, including PR reviews and the 0.1.3 GitHub Release, remains available in the archived [dsh-edge-history repository](https://github.com/pawaca/dsh-edge-history).
 
 ## Run
 
@@ -107,6 +109,7 @@ pnpm --filter dsh-edge dev
 ## Contributing and support
 
 - Report dsh-edge bugs and installation problems in this repository's [Issues](https://github.com/pawaca/dsh-edge/issues).
+- Report vulnerabilities through the [private security process](SECURITY.md), not a public Issue.
 - Follow [CONTRIBUTING.md](CONTRIBUTING.md) for repository changes.
 - Agents working in the repository must follow [AGENTS.md](AGENTS.md).
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -61,7 +61,7 @@ Durable Object 数据会保留。Cloudflare secret 只能替换、不能读回�
 
 ## 当前范围
 
-`dsh-edge` 处于开发者预览阶段。首个公开版本聚焦完整的个人使用路径：上游对话和工作区、持久会话、模型选择、Web Search、工作区文件操作、命令执行，以及上游浏览器体验。
+`dsh-edge` 处于开发者预览阶段。当前预览版本聚焦完整的个人使用路径：上游对话和工作区、持久会话、模型选择、Web Search、工作区文件操作、命令执行，以及上游浏览器体验。
 
 部署有意采用 single-owner 模式，不提供注册、多用户、角色或租户路由。附件与图片、远程 MCP、Skills、Workflows、Jobs 和 Subagents 尚未适配 Edge 运行时。`web_fetch` 在运行时具备明确的 SSRF、私网地址和重定向策略前保持关闭。
 
@@ -80,7 +80,9 @@ Durable Object 数据会保留。Cloudflare secret 只能替换、不能读回�
 
 `apps/dsh-edge/standalone` 下的隔离装配固定一个上游版本，并记录每项无法避免的 package patch。上游已经定义的 schema 或服务约定保持不变，除非 Edge 环境使其无法成立。
 
-上游架构与插件开发请使用 [DeepSeek Harness 仓库](https://github.com/deepseek-ai/deepseek-harness)和 [reference 文档](https://deepseek-harness.github.io/deepseek-harness/reference/)。
+上游架构与插件开发请使用 [DeepSeek Harness 仓库](https://github.com/deepseek-ai/deepseek-harness) 和 [reference 文档](https://deepseek-harness.github.io/deepseek-harness/reference/)。
+
+Standalone 仓库切换前的开发历史，包括 PR Review 和 0.1.3 GitHub Release，保留在已归档的 [dsh-edge-history 仓库](https://github.com/pawaca/dsh-edge-history)中。
 
 ## 运行
 
@@ -107,6 +109,7 @@ pnpm --filter dsh-edge dev
 ## 贡献与支持
 
 - 请在本仓库的 [Issues](https://github.com/pawaca/dsh-edge/issues) 中报告 dsh-edge bug 和安装问题。
+- 漏洞请通过[私密安全流程](SECURITY.zh.md)报告，不要使用公开 Issue。
 - 修改仓库前请阅读 [CONTRIBUTING.md](CONTRIBUTING.md)。
 - 在仓库中工作的 Agent 必须遵循 [AGENTS.md](AGENTS.md)。
 

--- a/SECURITY.i18n.yaml
+++ b/SECURITY.i18n.yaml
@@ -2,5 +2,5 @@
 # last confirmed-consistent state. Both languages carry equal authority.
 # After editing either side, update both and re-record every pair with:
 #   pnpm run doc-pairs -- --write
-README.md: fd75df947af2633b6c4751ed3aa5e26f7a622652
-README.zh.md: 987ad34cfc1b33f7d29d94ec53bcc536c133ee81
+SECURITY.md: 86eb5e03811aae5d8f69b02e02261b3befb66417
+SECURITY.zh.md: 3d3e520a63f422d6a5ee4de1ee75a14482a7f94e

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security Policy
+
+English | [中文](SECURITY.zh.md)
+
+## Supported versions
+
+Security fixes target the version currently published on npm under `latest`. An actively tested prerelease published under `next` may also receive fixes, but prerelease users should upgrade when a replacement is published. Older versions are unsupported unless a security advisory says otherwise.
+
+## Report a vulnerability
+
+Use [GitHub private vulnerability reporting](https://github.com/pawaca/dsh-edge/security/advisories/new) for vulnerabilities in dsh-edge. Do not include exploit details, credentials, owner access keys, DeepSeek API keys, cookies, Worker secrets, or private deployment URLs in a public Issue or Discussion.
+
+Include the affected dsh-edge version and runtime mode, the security impact, minimal reproduction steps, and sanitized diagnostics when available. Reports are handled on a best-effort basis; the maintainer will confirm the affected surface before coordinating a fix and disclosure.
+
+Report vulnerabilities in Cloudflare, DeepSeek Harness, the DeepSeek API, or another upstream dependency to that project's security channel unless dsh-edge introduces the vulnerable behavior.
+
+## Security scope
+
+The single-owner authentication boundary, credential handling, Durable Object and VFS isolation, installer secret transport, Worker HTTP/WebSocket routes, Direct and Dynamic Loader command runtimes, and published npm artifact are in scope. Direct mode is intentionally not a Linux container and must not be exposed to untrusted users.

--- a/SECURITY.zh.md
+++ b/SECURITY.zh.md
@@ -1,0 +1,19 @@
+# 安全策略
+
+[English](SECURITY.md) | 中文
+
+## 支持版本
+
+安全修复面向 npm `latest` 当前指向的版本。发布在 `next` 下且正在测试的预发布版本也可能获得修复，但预发布用户应在替代版本发布后及时升级。除非安全公告另有说明，更早版本不受支持。
+
+## 报告漏洞
+
+请通过 [GitHub 私密漏洞报告](https://github.com/pawaca/dsh-edge/security/advisories/new) 报告 dsh-edge 漏洞。不要在公开 Issue 或 Discussion 中包含利用细节、credential、owner access key、DeepSeek API key、Cookie、Worker secret 或私有部署 URL。
+
+请尽量提供受影响的 dsh-edge 版本与运行模式、安全影响、最小复现步骤和经过脱敏的诊断信息。维护者会尽力处理报告，并在协调修复与披露前确认受影响范围，但不承诺固定响应时限。
+
+Cloudflare、DeepSeek Harness、DeepSeek API 或其他上游依赖中的漏洞，应提交到对应项目的安全渠道；只有 dsh-edge 引入了漏洞行为时才属于本项目范围。
+
+## 安全范围
+
+Single-owner 认证边界、credential 处理、Durable Object 与 VFS 隔离、安装器 secret 传输、Worker HTTP/WebSocket 路由、Direct 与 Dynamic Loader 命令运行时，以及已发布 npm artifact 均在范围内。Direct 模式有意不提供 Linux 容器隔离，不能暴露给不受信任用户。

--- a/apps/dsh-edge/README.i18n.yaml
+++ b/apps/dsh-edge/README.i18n.yaml
@@ -2,5 +2,5 @@
 # last confirmed-consistent state. Both languages carry equal authority.
 # After editing either side, update both and re-record every pair with:
 #   pnpm run doc-pairs -- --write
-README.md: 5f608201a8bdfae5834c9645e1984dbc7821558b
-README.zh.md: 8220e93a3fe70664201521c6732f30be091d4bb6
+README.md: 6e6c63c79b02c289f32253a1d17b29d21a886f1e
+README.zh.md: 4fd8147d555b7c376cd0af32dab5ac9fb62ef55c

--- a/apps/dsh-edge/README.md
+++ b/apps/dsh-edge/README.md
@@ -2,13 +2,13 @@
 
 English | [中文](README.zh.md)
 
-`dsh-edge` is the Cloudflare runtime prototype for DeepSeek Harness. One deployment maps its authenticated owner to one Durable Object whose SQLite-backed virtual filesystem survives requests. By default, an in-process just-bash backend runs commands against that same filesystem without a Linux container or Dynamic Worker.
+`dsh-edge` is the Cloudflare runtime for DeepSeek Harness. One deployment maps its authenticated owner to one Durable Object whose SQLite-backed virtual filesystem survives requests. By default, an in-process just-bash backend runs commands against that same filesystem without a Linux container or Dynamic Worker.
 
 `dsh-edge` is an independent community project. It is not affiliated with or endorsed by DeepSeek; DeepSeek Harness remains an upstream dependency under its own license.
 
 The checked-in Wrangler configuration exposes two deployment targets from the same application graph. The default target is direct mode for Workers Free and has no Worker Loader binding. The named `isolated` target adds the `LOADER` binding and requires Workers Paid, but does not fork the DSH protocol, storage, UI, or tool implementation.
 
-The prototype runs persistent conversations through the upstream Cordis-composed `ReactLoopAgent`, `AgentRegistry`, `LlmRuntime`, `ToolRuntime`, `SystemPrompt`, `SessionStore`, and `SessionPersistence`. Edge code only binds a request-scoped DeepSeek adapter and maps one native DSH `bash` tool definition onto Cloudflare Computer. Durable Object SQLite implements the upstream persistence backend contract; `PersistenceCoordinator` still owns write-behind, revisions, resume preparation, and crash recovery. Model history is projected from canonical events rather than persisted separately.
+The runtime runs persistent conversations through the upstream Cordis-composed `ReactLoopAgent`, `AgentRegistry`, `LlmRuntime`, `ToolRuntime`, `SystemPrompt`, `SessionStore`, and `SessionPersistence`. Edge code only binds a request-scoped DeepSeek adapter and maps one native DSH `bash` tool definition onto Cloudflare Computer. Durable Object SQLite implements the upstream persistence backend contract; `PersistenceCoordinator` still owns write-behind, revisions, resume preparation, and crash recovery. Model history is projected from canonical events rather than persisted separately.
 
 The browser is the upstream Web shell and upstream client-plugin bundles. A build-time assembler derives the browser roster from the upstream base and Web bundle configs, injects the standard `window.__DSH_BOOT__` graph, and publishes the result as Cloudflare static assets. The Durable Object implements the supported upstream `ApiProxy` methods through the standard HTTP carrier and supplies the two upstream downlinks as hibernatable WebSockets. Edge excludes client plugins whose host domains are absent instead of forking their UI code; this includes session-log export until its server endpoint exists. A small Edge-owned login shell protects the upstream UI and protocol without changing either one. Optional local-host plugins remain unavailable.
 
@@ -149,13 +149,13 @@ The same file also defines `env.isolated`, a complete Workers Paid target with t
 Run the guided installer without cloning this repository:
 
 ```sh
-pnpm dlx dsh-edge@latest install
+npx dsh-edge@latest install
 ```
 
 Upgrade an existing named Worker with the same runtime choice. The deployment keeps its Durable Object data; because Cloudflare secrets are write-only, the upgrade asks for the owner access key and DeepSeek API key again and replaces their active values:
 
 ```sh
-pnpm dlx dsh-edge@latest upgrade
+npx dsh-edge@latest upgrade
 ```
 
 The installer asks for the runtime before the account. The recommended `Free — Direct Shell` mode works on Workers Free and can use a detected Cloudflare account, open Cloudflare sign-in or registration, or create a temporary account without login. `Isolated — Dynamic Worker` requires Workers Paid and therefore offers only a detected or newly authenticated account. Cloudflare does not expose a reliable local entitlement check for Worker Loader, so an isolated install lets Cloudflare authorize the upload and turns a rejection into a choice between enabling Workers Paid and using direct mode.
@@ -170,7 +170,7 @@ Contributors can replay the complete Free temporary-account journey without a ke
 pnpm --filter dsh-edge example:install
 ```
 
-## Prototype API
+## Edge API
 
 - `POST /api/<upstream-method>` accepts the upstream `ClientRequest` envelope for the supported `ApiProxy` methods. The Web client currently uses session list/search/create/history/models/select/prompt/updateQueue/rename/fork/cancel, host description, workspace list/create/rename/delete/reorder/archive, skills, agent presets, settings and credential descriptions, and LLM catalogs. `agentPreset.read` renders the programmatic Edge composition through the upstream read-only viewer, and `credentials.describe` returns credential state without a value. Search projects canonical current-message surfaces and returns only bounded upstream result values. Fork copies a completed-turn prefix through the canonical session seed format and retains parent lineage; Edge refuses a seed above 8,192 events or 8 MiB rather than materializing an unbounded Durable Object history. Queue mutations edit, remove, or promote an item through the live upstream Agent inbox; the synchronous inbox mutation is the upstream acceptance point, while the persistence coordinator owns later write-behind and retirement retry. Workspace mutations persist the upstream workspace-domain global and record shapes through the Durable Object backend. Archive preserves the session log and workspace slot; unary responses and Host frames carry the same full snapshots as upstream.
 - `GET /login` renders the Edge-owned owner form; `POST /api/auth/login` exchanges the configured access key for a signed cookie, `GET /api/auth/session` reports cookie validity, and `POST /api/auth/logout` clears it.

--- a/apps/dsh-edge/README.zh.md
+++ b/apps/dsh-edge/README.zh.md
@@ -2,13 +2,13 @@
 
 [English](README.md) | 中文
 
-`dsh-edge` 是 DeepSeek Harness 的 Cloudflare 运行时原型。每次部署把通过认证的 owner 固定映射到一个 Durable Object，其基于 SQLite 的虚拟文件系统可跨请求持久保存。默认情况下，进程内 just-bash 后端直接在同一文件系统上执行命令，不依赖 Linux 容器或 Dynamic Worker。
+`dsh-edge` 是 DeepSeek Harness 的 Cloudflare 运行时。每次部署把通过认证的 owner 固定映射到一个 Durable Object，其基于 SQLite 的虚拟文件系统可跨请求持久保存。默认情况下，进程内 just-bash 后端直接在同一文件系统上执行命令，不依赖 Linux 容器或 Dynamic Worker。
 
 `dsh-edge` 是独立的社区项目，与 DeepSeek 没有隶属关系，也未获得 DeepSeek 官方背书；DeepSeek Harness 仍是按其自身许可证使用的上游依赖。
 
 仓库提交的 Wrangler 配置从同一套应用 graph 暴露两个部署目标。默认目标是面向 Workers Free 的 direct 模式，不包含 Worker Loader binding。命名的 `isolated` 目标会添加 `LOADER` binding，并且需要 Workers Paid，但不会 fork DSH protocol、storage、UI 或 tool implementation。
 
-该原型通过上游 Cordis 组合的 `ReactLoopAgent`、`AgentRegistry`、`LlmRuntime`、`ToolRuntime`、`SystemPrompt`、`SessionStore` 和 `SessionPersistence` 运行持久对话。Edge 代码只绑定请求作用域的 DeepSeek 适配器，并把一个原生 DSH `bash` 工具定义映射到 Cloudflare Computer。Durable Object SQLite 实现上游持久化后端约定，write-behind、revision、恢复准备和崩溃恢复仍由 `PersistenceCoordinator` 负责。模型历史从 canonical 事件投影，不再单独持久化。
+该运行时通过上游 Cordis 组合的 `ReactLoopAgent`、`AgentRegistry`、`LlmRuntime`、`ToolRuntime`、`SystemPrompt`、`SessionStore` 和 `SessionPersistence` 运行持久对话。Edge 代码只绑定请求作用域的 DeepSeek 适配器，并把一个原生 DSH `bash` 工具定义映射到 Cloudflare Computer。Durable Object SQLite 实现上游持久化后端约定，write-behind、revision、恢复准备和崩溃恢复仍由 `PersistenceCoordinator` 负责。模型历史从 canonical 事件投影，不再单独持久化。
 
 浏览器直接使用上游 Web shell 和上游客户端插件包。构建期 assembler 根据上游 base 与 Web 组合包配置推导浏览器 roster，注入标准 `window.__DSH_BOOT__` graph，并把结果发布为 Cloudflare 静态资源。Durable Object 通过标准 HTTP carrier 实现受支持的上游 `ApiProxy` 方法，并以支持休眠的 WebSocket 提供两条上游 downlink。Edge 会排除缺少对应 host domain 的客户端插件，而不会 fork 其 UI 代码；在服务端 endpoint 可用前，session log export 也属于排除项。一个很小的 Edge 登录外壳会保护上游 UI 与协议，不修改两者本身。可选的本地 host 插件仍不可用。
 
@@ -149,13 +149,13 @@ Cloudflare static assets -> upstream Web shell + client plugin graph
 无需克隆仓库即可运行引导式安装器：
 
 ```sh
-pnpm dlx dsh-edge@latest install
+npx dsh-edge@latest install
 ```
 
 选择相同 runtime 并输入现有 Worker 名称即可升级。部署会保留 Durable Object 数据；由于 Cloudflare secret 只能写入而不能读取，升级会再次要求 owner access key 与 DeepSeek API key，并用输入值替换当前生效值：
 
 ```sh
-pnpm dlx dsh-edge@latest upgrade
+npx dsh-edge@latest upgrade
 ```
 
 安装器会先询问运行时，再询问账户。推荐的 `Free — Direct Shell` 模式可在 Workers Free 上运行，并可使用检测到的 Cloudflare 账户、打开 Cloudflare 登录或注册，也可在不登录的情况下创建临时账户。`Isolated — Dynamic Worker` 需要 Workers Paid，因此只提供已检测到或新认证的账户。Cloudflare 没有提供可靠的本地 Worker Loader entitlement 检查；isolated 安装会由 Cloudflare 对上传进行授权，并在被拒绝时提示启用 Workers Paid 或改用 direct 模式。
@@ -170,7 +170,7 @@ pnpm dlx dsh-edge@latest upgrade
 pnpm --filter dsh-edge example:install
 ```
 
-## 原型 API
+## Edge API
 
 - `POST /api/<upstream-method>` 接受受支持 `ApiProxy` 方法的上游 `ClientRequest` envelope。Web client 当前使用 session list/search/create/history/models/select/prompt/updateQueue/rename/fork/cancel、host description、workspace list/create/rename/delete/reorder/archive、skills、agent presets、settings 与 credential description，以及 LLM catalog。`agentPreset.read` 会通过上游只读 viewer 渲染程序化 Edge composition，`credentials.describe` 则返回不含 value 的 credential state。Search 会投影 canonical current-message surface，并且只返回有界的上游 result value。Fork 会通过 canonical session seed format 复制 completed-turn prefix，并保留 parent lineage；超过 8,192 个事件或 8 MiB 的 seed 会被 Edge 拒绝，而不会在 Durable Object 中物化无界 history。Queue mutation 通过 live upstream Agent inbox 编辑、移除或把一项提升为 steering；同步 inbox mutation 是上游接纳点，后续 write-behind 与 retirement retry 由 persistence coordinator 负责。Workspace mutation 通过 Durable Object backend 持久化上游 workspace-domain global 与 record shape。Archive 保留 session log 与 workspace slot；unary response 与 Host frame 携带和上游一致的完整 snapshot。
 - `GET /login` 渲染 Edge 持有的 owner form；`POST /api/auth/login` 用已配置的 access key 换取 signed cookie，`GET /api/auth/session` 报告 cookie 是否有效，`POST /api/auth/logout` 清除 cookie。

--- a/apps/dsh-edge/src/index.ts
+++ b/apps/dsh-edge/src/index.ts
@@ -101,7 +101,7 @@ export default {
           const contents = await readBoundedText(
             request,
             MAX_TEXT_FILE_BYTES,
-            'Text files are limited to 1 MiB in the prototype API.',
+            'Text files are limited to 1 MiB in the Edge API.',
           )
           await workspace.fs.mkdir(parentDirectory(path), { recursive: true })
           await workspace.fs.writeFile(path, contents)

--- a/apps/dsh-edge/src/workspace.ts
+++ b/apps/dsh-edge/src/workspace.ts
@@ -68,7 +68,7 @@ export async function readBoundedWorkspaceFile(
 ): Promise<Uint8Array<ArrayBuffer>> {
   const entry = await files.stat(path)
   if (entry.size > MAX_TEXT_FILE_BYTES) {
-    throw new EdgeWorkspaceRequestError(413, 'Text files are limited to 1 MiB in the prototype API.')
+    throw new EdgeWorkspaceRequestError(413, 'Text files are limited to 1 MiB in the Edge API.')
   }
   const stream = await files.readFile(path)
   const reader = stream.getReader()
@@ -84,7 +84,7 @@ export async function readBoundedWorkspaceFile(
         await reader.cancel().catch(() => undefined)
         throw new EdgeWorkspaceRequestError(
           413,
-          'Text files are limited to 1 MiB in the prototype API.',
+          'Text files are limited to 1 MiB in the Edge API.',
         )
       }
       chunks.push(next.value)

--- a/apps/dsh-edge/tests/install.snapshot.mjs
+++ b/apps/dsh-edge/tests/install.snapshot.mjs
@@ -3,7 +3,7 @@ import { runKeylessInstall } from '../examples/install-keyless.mjs'
 
 describe.skipIf(process.platform === 'win32')('dsh-edge install transcript', () => {
   it('runs the shipped no-account Free installer through its real bin and prompts', async () => {
-    expect(await runKeylessInstall())
+    await expect(await runKeylessInstall())
       .toMatchFileSnapshot('./snapshots/edge-install.expected.txt')
   }, 30_000)
 })

--- a/apps/dsh-edge/tests/session.browser.snapshot.mjs
+++ b/apps/dsh-edge/tests/session.browser.snapshot.mjs
@@ -78,7 +78,7 @@ describe('dsh-edge assembled browser snapshot', () => {
       }).count())
         .toBe(1)
       expect(await page.evaluate(() => globalThis.__dshEdgeCopiedText))
-        .toBe('pnpm dlx dsh-edge@latest upgrade')
+        .toBe('npx dsh-edge@latest upgrade')
       const edgeSettingsSnapshot = await stableAria(page, '[role="dialog"]')
       await expect(normalize(edgeSettingsSnapshot))
         .toMatchFileSnapshot('./snapshots/edge-settings.expected.md')

--- a/apps/dsh-edge/tests/session.snapshot.mjs
+++ b/apps/dsh-edge/tests/session.snapshot.mjs
@@ -93,7 +93,7 @@ describe('dsh-edge assembled runtime snapshot', () => {
         liveEvents: normalize(liveEvents),
         replayedEvents: normalize(replayedEvents),
       }
-      expect(snapshot).toMatchFileSnapshot('./snapshots/edge-turn.expected.txt')
+      await expect(snapshot).toMatchFileSnapshot('./snapshots/edge-turn.expected.txt')
 
       const searchResponse = await request(worker, `/api/sessions/${sessionId}/turn`, {
         method: 'POST',
@@ -110,7 +110,7 @@ describe('dsh-edge assembled runtime snapshot', () => {
       const searchResult = searchEvents.find(event => event.type === 'tool/result')
       const finalMessage = [...searchEvents].reverse()
         .find(event => event.type === 'assistant/message')
-      expect(normalize({
+      await expect(normalize({
         toolNames: requestHeader.data.header.tools.map(tool => tool.name),
         searchGuidance: requestHeader.data.header.system.split('\n\n').at(-1),
         call: searchCall.data,

--- a/apps/dsh-edge/vitest.snapshot.config.ts
+++ b/apps/dsh-edge/vitest.snapshot.config.ts
@@ -5,6 +5,9 @@ export default defineConfig({
     include: ['apps/dsh-edge/tests/**/*.snapshot.mjs'],
     environment: 'node',
     pool: 'forks',
+    // Each snapshot owns a Wrangler dev runtime (and one owns Chromium).
+    // Serial execution avoids local port/process contention between runtimes.
+    maxWorkers: 1,
     testTimeout: 120_000,
     hookTimeout: 30_000,
   },

--- a/packages/client/ui-edge/src/client/store.ts
+++ b/packages/client/ui-edge/src/client/store.ts
@@ -2,7 +2,7 @@ import { compareVersions, validate } from 'compare-versions'
 import { createSnapshotStore, type SnapshotStore } from '@deepseek-ai/dsh-client-runtime/client'
 
 /** Repeatable command for upgrading an existing Edge deployment. */
-const DSH_EDGE_UPGRADE_COMMAND = 'pnpm dlx dsh-edge@latest upgrade'
+const DSH_EDGE_UPGRADE_COMMAND = 'npx dsh-edge@latest upgrade'
 
 /** Public release history for the Edge distribution. */
 export const DSH_EDGE_RELEASES_URL = 'https://github.com/pawaca/dsh-edge/releases'

--- a/packages/client/ui-edge/tests/store.client.spec.ts
+++ b/packages/client/ui-edge/tests/store.client.spec.ts
@@ -111,7 +111,7 @@ describe('Edge settings controller', () => {
     await controller.load()
     expect(controller.store.getSnapshot()).toMatchObject({ releaseStatus: 'update-available', latestVersion: '2.0.0' })
     await controller.copyUpgrade()
-    expect(copy).toHaveBeenCalledWith('pnpm dlx dsh-edge@latest upgrade')
+    expect(copy).toHaveBeenCalledWith('npx dsh-edge@latest upgrade')
     expect(controller.store.getSnapshot()).toMatchObject({ copied: true, releaseStatus: 'update-available' })
   })
 })


### PR DESCRIPTION
## Summary

- update the 0.2 roadmap and archive links after the clean-root cutover
- add bilingual security reporting guidance and simplify dependency automation to coordinated updates
- standardize public install/upgrade guidance on npx and remove stale prototype wording
- await file snapshots and serialize Wrangler/Chromium snapshot workers to prevent false passes and runtime contention

## Validation

- `fnm exec --using 24.15.0 pnpm run check`
- `fnm exec --using 24.15.0 pnpm --filter dsh-edge run bundle:workers`
- `fnm exec --using 24.15.0 pnpm --filter dsh-edge run test:snapshot`
- Direct Worker: 686,050 gzip bytes against the 921,600-byte repository budget
- standalone verification: Harness 0.1.0-rc.7, 6 patches, 28 client plugins, both Worker modes

## Follow-up boundary

Prerelease channel selection and GitHub Release publication remain in the separate alpha-readiness stage documented in the roadmap.