### PR TITLE
test: settle rejected Windows WebSockets

### DIFF
--- a/apps/dsh-edge/tests/session.integration.mjs
+++ b/apps/dsh-edge/tests/session.integration.mjs
@@ -1134,8 +1134,22 @@ function rejectedDownlinkStatus(path, headers) {
   return new Promise((resolve, reject) => {
     const socket = new WebSocket(`ws://${worker.address}:${worker.port}${path}`, { headers })
     socket.once('unexpected-response', (_request, response) => {
+      const statusCode = response.statusCode
+      const settle = () => { resolve(statusCode) }
+      const settleNetworkError = (error) => {
+        if (error?.code === 'ECONNRESET') {
+          settle()
+          return
+        }
+        reject(error)
+      }
+      response.once('end', settle)
+      response.once('aborted', settle)
+      response.once('error', settleNetworkError)
+      // Windows can reset a rejected upgrade after delivering its HTTP status.
+      // Keep ownership of the raw socket until that rejection has settled.
+      response.socket.once('error', settleNetworkError)
       response.resume()
-      resolve(response.statusCode)
     })
     socket.once('open', () => {
       socket.close(1000, 'unexpected authenticated connection')


### PR DESCRIPTION
## Summary

- keep the rejected WebSocket HTTP response and its raw socket observed until the response ends or aborts
- treat only the expected post-status Windows `ECONNRESET` as completion
- continue rejecting every other response/socket network error

## Why

Release run 32430047382 reached the Windows durable-state/runtime parity gate, received the expected rejected WebSocket status, then crashed on a delayed unhandled raw-socket `ECONNRESET`. npm publication and GitHub Release creation had not started.

## Validation

- `node apps/dsh-edge/tests/run-session-integration.mjs` (Direct and Isolated passed)
- `pnpm run check` (22 files, 191 tests, docs, lint, typecheck)
- `git diff --check`