### PR TITLE
fix: align installer hero output

### DIFF
--- a/apps/dsh-edge/scripts/cli.mjs
+++ b/apps/dsh-edge/scripts/cli.mjs
@@ -20,6 +20,7 @@ const INTERRUPT_EXIT_CODES = new Map([
 ])
 const OUTPUT_DRAIN_TIMEOUT_MS = 1_000
 const HERO_MIN_COLUMNS = 68
+const CLACK_INTRO_GUTTER = '   '
 const DSH_EDGE_HERO = String.raw`   ____  ____  _   _       _____ ____   ____ _____
   |  _ \/ ___|| | | |     | ____|  _ \ / ___| ____|
   | | | \___ \| |_| |_____|  _| | | | | |  _|  _|
@@ -51,12 +52,15 @@ export function renderInstallerIntro(command, {
   version = edgePackage.version,
 } = {}) {
   if (!isTTY || columns < HERO_MIN_COLUMNS) return `dsh-edge ${command} · v${version}`
-  return [
+  const content = [
     DSH_EDGE_HERO,
     '',
     'DeepSeek Harness on Cloudflare',
     `v${version} · community project · ${command}`,
   ].join('\n')
+  return content.split('\n')
+    .map((line, index) => index === 0 || line === '' ? line : `${CLACK_INTRO_GUTTER}${line}`)
+    .join('\n')
 }
 
 export function createInstallerUi(

--- a/apps/dsh-edge/tests/cli.spec.ts
+++ b/apps/dsh-edge/tests/cli.spec.ts
@@ -77,16 +77,14 @@ describe('dsh-edge CLI', () => {
   })
 
   it('renders a product hero only when the terminal has room for it', () => {
-    expect(renderInstallerIntro('install', {
+    const hero = renderInstallerIntro('install', {
       columns: 100,
       isTTY: true,
       version: '0.2.0-alpha.2',
-    })).toContain('____  ____  _   _')
-    expect(renderInstallerIntro('install', {
-      columns: 100,
-      isTTY: true,
-      version: '0.2.0-alpha.2',
-    })).toContain('DeepSeek Harness on Cloudflare')
+    })
+    expect(hero).toContain('____  ____  _   _')
+    expect(hero).toContain('DeepSeek Harness on Cloudflare')
+    expect(hero.split('\n').filter(Boolean).slice(1).every(line => line.startsWith('   '))).toBe(true)
     expect(renderInstallerIntro('upgrade', {
       columns: 60,
       isTTY: true,

--- a/apps/dsh-edge/tests/snapshots/edge-install.expected.txt
+++ b/apps/dsh-edge/tests/snapshots/edge-install.expected.txt
@@ -1,11 +1,11 @@
 TERMINAL
 ┌     ____  ____  _   _       _____ ____   ____ _____
-  |  _ \/ ___|| | | |     | ____|  _ \ / ___| ____|
-  | | | \___ \| |_| |_____|  _| | | | | |  _|  _|
-  | |_| |___) |  _  |_____| |___| |_| | |_| | |___
-  |____/|____/|_| |_|     |_____|____/ \____|_____|
-DeepSeek Harness on Cloudflare
-v0.2.0-alpha.1 · community project · install
+     |  _ \/ ___|| | | |     | ____|  _ \ / ___| ____|
+     | | | \___ \| |_| |_____|  _| | | | | |  _|  _|
+     | |_| |___) |  _  |_____| |___| |_| | |_| | |___
+     |____/|____/|_| |_|     |_____|____/ \____|_____|
+   DeepSeek Harness on Cloudflare
+   v0.2.0-alpha.1 · community project · install
 │
 ◆  Choose a runtime
 │  ● Free — Direct Shell (recommended; runs on Workers Free)


### PR DESCRIPTION
## Summary

- account for Clack's first-line-only intro gutter when rendering the multiline installer hero
- keep every continuation line aligned with the first ASCII row
- update the focused assertion and terminal snapshot

## Validation

- `pnpm run check` — 23 files / 201 tests, lint, typecheck, docs
- focused CLI suite — 26 tests
- `pnpm --filter dsh-edge run test:snapshot` — 3 snapshot suites
- packed npm artifact verified outside the workspace; Direct and Isolated Workers both started

## Scope

This changes only Hero rendering and its tests. Cloudflare account ordering is intentionally unchanged.
