### PR TITLE
fix: align alpha.2 installer hero

### DIFF
--- a/apps/dsh-edge/scripts/cli.d.mts
+++ b/apps/dsh-edge/scripts/cli.d.mts
@@ -12,7 +12,12 @@ export type InstallerCommand = 'install' | 'upgrade'
 export function parseCommand(args: string[]): InstallerCommand | 'help' | 'version'
 export function renderInstallerIntro(
   command: InstallerCommand,
-  options?: { columns?: number; isTTY?: boolean; version?: string },
+  options?: {
+    columns?: number
+    isTTY?: boolean
+    upstreamVersion?: string
+    version?: string
+  },
 ): string
 export function createInstallerUi(
   clack?: typeof import('@clack/prompts'),

--- a/apps/dsh-edge/scripts/cli.mjs
+++ b/apps/dsh-edge/scripts/cli.mjs
@@ -20,12 +20,11 @@ const INTERRUPT_EXIT_CODES = new Map([
 ])
 const OUTPUT_DRAIN_TIMEOUT_MS = 1_000
 const HERO_MIN_COLUMNS = 68
-const CLACK_INTRO_GUTTER = '   '
-const DSH_EDGE_HERO = String.raw`   ____  ____  _   _       _____ ____   ____ _____
-  |  _ \/ ___|| | | |     | ____|  _ \ / ___| ____|
-  | | | \___ \| |_| |_____|  _| | | | | |  _|  _|
-  | |_| |___) |  _  |_____| |___| |_| | |_| | |___
-  |____/|____/|_| |_|     |_____|____/ \____|_____|`
+const DSH_EDGE_HERO = String.raw` ____  ____  _   _       _____ ____   ____ _____
+|  _ \/ ___|| | | |     | ____|  _ \ / ___| ____|
+| | | \___ \| |_| |_____|  _| | | | | |  _|  _|
+| |_| |___) |  _  |_____| |___| |_| | |_| | |___
+|____/|____/|_| |_|     |_____|____/ \____|_____|`
 
 export class InstallInterruptedError extends InstallCancelledError {
   constructor(signal) {
@@ -50,17 +49,19 @@ export function renderInstallerIntro(command, {
   columns = 80,
   isTTY = false,
   version = edgePackage.version,
+  upstreamVersion = edgePackage.dshEdge.upstreamVersion,
 } = {}) {
-  if (!isTTY || columns < HERO_MIN_COLUMNS) return `dsh-edge ${command} · v${version}`
-  const content = [
+  if (!isTTY || columns < HERO_MIN_COLUMNS) {
+    return `dsh-edge ${command} · ${version} · Harness ${upstreamVersion}`
+  }
+  return [
+    '',
     DSH_EDGE_HERO,
     '',
     'DeepSeek Harness on Cloudflare',
-    `v${version} · community project · ${command}`,
+    `dsh-edge ${version} · Harness ${upstreamVersion}`,
+    `community project · ${command}`,
   ].join('\n')
-  return content.split('\n')
-    .map((line, index) => index === 0 || line === '' ? line : `${CLACK_INTRO_GUTTER}${line}`)
-    .join('\n')
 }
 
 export function createInstallerUi(

--- a/apps/dsh-edge/tests/cli.spec.ts
+++ b/apps/dsh-edge/tests/cli.spec.ts
@@ -81,20 +81,27 @@ describe('dsh-edge CLI', () => {
       columns: 100,
       isTTY: true,
       version: '0.2.0-alpha.2',
+      upstreamVersion: '0.1.0-rc.7',
     })
-    expect(hero).toContain('____  ____  _   _')
+    const lines = hero.split('\n')
+    expect(lines[0]).toBe('')
+    expect(lines[1]).toBe(' ____  ____  _   _       _____ ____   ____ _____')
+    expect(lines[2]).toBe('|  _ \\/ ___|| | | |     | ____|  _ \\ / ___| ____|')
     expect(hero).toContain('DeepSeek Harness on Cloudflare')
-    expect(hero.split('\n').filter(Boolean).slice(1).every(line => line.startsWith('   '))).toBe(true)
+    expect(hero).toContain('dsh-edge 0.2.0-alpha.2 · Harness 0.1.0-rc.7')
+    expect(hero).toContain('community project · install')
     expect(renderInstallerIntro('upgrade', {
       columns: 60,
       isTTY: true,
       version: '0.2.0-alpha.2',
-    })).toBe('dsh-edge upgrade · v0.2.0-alpha.2')
+      upstreamVersion: '0.1.0-rc.7',
+    })).toBe('dsh-edge upgrade · 0.2.0-alpha.2 · Harness 0.1.0-rc.7')
     expect(renderInstallerIntro('install', {
       columns: 100,
       isTTY: false,
       version: '0.2.0-alpha.2',
-    })).toBe('dsh-edge install · v0.2.0-alpha.2')
+      upstreamVersion: '0.1.0-rc.7',
+    })).toBe('dsh-edge install · 0.2.0-alpha.2 · Harness 0.1.0-rc.7')
   })
 
   it('executes through a package-manager-style bin symlink', () => {

--- a/apps/dsh-edge/tests/session.browser.snapshot.mjs
+++ b/apps/dsh-edge/tests/session.browser.snapshot.mjs
@@ -202,6 +202,13 @@ describe('dsh-edge assembled browser snapshot', () => {
       ).toBeGreaterThanOrEqual(1)
       await page.mouse.move(0, 0)
       await expect.poll(() => page.getByRole('tooltip').count()).toBe(0)
+      await expect.poll(
+        () => page.getByRole('button', {
+          name: 'Select model, current deepseek-v4-flash',
+          exact: true,
+        }).count(),
+        { timeout: 15_000 },
+      ).toBe(1)
 
       const transcript = await stableAria(page, '[class*="centerCol"]')
       await expect(normalize(transcript))

--- a/apps/dsh-edge/tests/snapshots/edge-install.expected.txt
+++ b/apps/dsh-edge/tests/snapshots/edge-install.expected.txt
@@ -1,11 +1,13 @@
 TERMINAL
-┌     ____  ____  _   _       _____ ____   ____ _____
-     |  _ \/ ___|| | | |     | ____|  _ \ / ___| ____|
-     | | | \___ \| |_| |_____|  _| | | | | |  _|  _|
-     | |_| |___) |  _  |_____| |___| |_| | |_| | |___
-     |____/|____/|_| |_|     |_____|____/ \____|_____|
-   DeepSeek Harness on Cloudflare
-   v0.2.0-alpha.2 · community project · install
+┌
+ ____  ____  _   _       _____ ____   ____ _____
+|  _ \/ ___|| | | |     | ____|  _ \ / ___| ____|
+| | | \___ \| |_| |_____|  _| | | | | |  _|  _|
+| |_| |___) |  _  |_____| |___| |_| | |_| | |___
+|____/|____/|_| |_|     |_____|____/ \____|_____|
+DeepSeek Harness on Cloudflare
+dsh-edge 0.2.0-alpha.2 · Harness 0.1.0-rc.7
+community project · install
 │
 ◆  Choose a runtime
 │  ● Free — Direct Shell (recommended; runs on Workers Free)

--- a/docs/releases/0.2.0-alpha.2.i18n.yaml
+++ b/docs/releases/0.2.0-alpha.2.i18n.yaml
@@ -2,5 +2,5 @@
 # last confirmed-consistent state. Both languages carry equal authority.
 # After editing either side, update both and re-record every pair with:
 #   pnpm run doc-pairs -- --write
-0.2.0-alpha.2.md: 1384460f57bc817c6ee919b7aca8953751b13eba
-0.2.0-alpha.2.zh.md: 930a0182b39e7ce89aabd26ab5b41b1c97436b17
+0.2.0-alpha.2.md: 1c70f87dfab30a74427db6c408936f9e3ea1ef81
+0.2.0-alpha.2.zh.md: 5ddf9d42f74ffce9ffcf1e00631b3ac816922cc6

--- a/docs/releases/0.2.0-alpha.2.md
+++ b/docs/releases/0.2.0-alpha.2.md
@@ -6,7 +6,7 @@ This prerelease focuses on a clearer first-run experience and a more portable re
 
 ## Highlights
 
-- Adds a recognizable, dependency-free dsh-edge installer hero with the product purpose, package version, community-project boundary, and selected operation.
+- Adds a recognizable, dependency-free dsh-edge installer hero that clears the terminal frame before drawing, keeps the artwork naturally left-aligned, and labels the package version alongside the pinned Harness version, community-project boundary, and selected operation.
 - Observes the public health endpoint after Wrangler accepts an upload, so the installer can distinguish a ready Worker from normal Cloudflare propagation delay.
 - Explains that activation usually takes 10–30 seconds, waits for at most 45 seconds, and presents explicit ready, pending, or recovery guidance without sending owner or DeepSeek credentials.
 - Keeps Wrangler acceptance as the installation success boundary: a delayed public route never turns an accepted deployment into a failed install.

--- a/docs/releases/0.2.0-alpha.2.zh.md
+++ b/docs/releases/0.2.0-alpha.2.zh.md
@@ -6,7 +6,7 @@
 
 ## 主要变化
 
-- 安装器新增不依赖第三方包的 dsh-edge Hero，明确展示产品用途、package version、社区项目边界和当前操作。
+- 安装器新增不依赖第三方包的 dsh-edge Hero；字符画会先避开终端框线并保持自然左对齐，同时明确标注 package version、固定的 Harness version、社区项目边界和当前操作。
 - Wrangler 接受上传后观察公开健康检查端点，让安装器可以区分 Worker 已就绪和 Cloudflare 正常传播延迟。
 - 提示激活通常需要 10–30 秒，最多等待 45 秒，并在不发送 owner 或 DeepSeek 凭证的前提下展示明确的已就绪、等待中或恢复指引。
 - Wrangler 接受上传仍是安装成功边界：公开路由延迟不会把已接受的部署误判为安装失败。


### PR DESCRIPTION
## Summary

- put the Clack intro corner on its own line and restore the ASCII art's natural left alignment
- show the dsh-edge package version beside the pinned Harness version from package metadata
- keep narrow and non-TTY output version-aware, and update the bilingual alpha.2 notes and installer snapshot

## Validation

- CLI test: 26 passed
- complete runtime/browser/installer snapshots: 3 passed
- bilingual documentation and type checks passed
- Node 24 pack rebuilt and verified the tarball outside the workspace; Direct and Isolated installed artifacts both started

Publication remains paused until this PR is reviewed and merged.