### PR TITLE
test: disambiguate rc8 Edge settings selector

### DIFF
--- a/apps/dsh-edge/tests/session.browser.snapshot.mjs
+++ b/apps/dsh-edge/tests/session.browser.snapshot.mjs
@@ -70,7 +70,9 @@ describe('dsh-edge assembled browser snapshot', () => {
 
       await page.locator('button[aria-haspopup="dialog"]').last().click()
       const settings = page.getByRole('dialog', { name: 'Settings', exact: true })
-      await settings.getByRole('button', { name: 'DSH Edge', exact: true }).click()
+      await settings.getByRole('navigation')
+        .getByRole('button', { name: 'DSH Edge', exact: true })
+        .click()
       await expect.poll(() => settings.getByText('0.2.0-alpha.3', { exact: true }).count()).toBe(1)
       await settings.getByRole('button', { name: 'Copy upgrade command', exact: true }).click()
       await expect.poll(() => settings.getByRole('button', {


### PR DESCRIPTION
## Summary

- scope the DSH Edge settings click to the settings navigation
- avoid the rc8 model selector that now exposes the same accessible name
- restore the merged-master release gate without changing runtime behavior

## Evidence

- `pnpm run build`
- `pnpm --filter dsh-edge run test:snapshot` (3 passed)
- pre-push typecheck passed
- `git diff --check`