### PR TITLE
test: stabilize image browser snapshot before alpha release

### DIFF
--- a/apps/dsh-edge/tests/session.browser.snapshot.mjs
+++ b/apps/dsh-edge/tests/session.browser.snapshot.mjs
@@ -228,6 +228,13 @@ describe('dsh-edge assembled browser snapshot', () => {
         }).count(),
         { timeout: 15_000 },
       ).toBe(1)
+      await expect.poll(
+        () => page.getByRole('button', {
+          name: 'one-pixel.png, click to view original',
+          exact: true,
+        }).getByRole('img', { name: 'one-pixel.png', exact: true }).count(),
+        { timeout: 15_000 },
+      ).toBeGreaterThanOrEqual(1)
 
       const transcript = await stableAria(page, '[class*="centerCol"]')
       await expect(normalize(transcript))


### PR DESCRIPTION
## Summary

- wait for the upstream attachment image element to replace its loading state before taking the transcript ARIA snapshot
- keep the expected snapshot strict instead of accepting the transient loading placeholder
- unblock the Windows release verifier before any npm publication occurred

## Evidence

- failed release run: https://github.com/pawaca/dsh-edge/actions/runs/32537177077
- `pnpm run check` — 242 tests passed
- `pnpm --filter dsh-edge run test:snapshot` — 4 snapshots passed
- focused browser snapshot passed twice more consecutively

## Release state

The failed workflow stopped before npm publication and GitHub Release creation. After this PR is reviewed and merged, the unpublished `dsh-edge-v0.3.0-alpha.1` tag will be advanced to the new reviewed master commit and the protected release workflow retried.