### PR TITLE
feat(edge): make credential provider writable with DO storage

### DIFF
--- a/.agents/notes/implemented/architecture/2026-08-22-dsh-edge-v0.4-multi-provider-vision.md
+++ b/.agents/notes/implemented/architecture/2026-08-22-dsh-edge-v0.4-multi-provider-vision.md
@@ -1,0 +1,92 @@
+# Agent Note: dsh-edge 0.4 multi-provider vision
+
+Status: active — Stage 1 in progress
+
+English | [中文](2026-08-22-dsh-edge-v0.4-multi-provider-vision.zh.md)
+
+## Outcome
+
+dsh-edge 0.4 adds runtime-configurable LLM providers and writable credentials, enabling users to add Anthropic, OpenAI, and custom OpenAI-compatible providers from the browser Settings page without redeployment. The upstream Settings subsystem, Models page UI, and credential-provider seam handle provider management; dsh-edge composes a Durable Object storage backend for both settings persistence and credential storage.
+
+Existing deployments remain backward compatible: Worker environment secrets continue to work as a fallback source, and no migration is required.
+
+## Non-negotiable ownership boundary
+
+For every capability, use this order and record why a lower choice was necessary:
+
+1. Consume the published upstream package, plugin, UI, protocol, schema, and default catalog unchanged.
+2. Compose an upstream service/provider/plugin slot.
+3. Implement the smallest Edge-owned adapter behind an upstream interface.
+4. Add a `ui-edge` contribution only for Cloudflare-specific product state or actions.
+5. Apply an exact-version package patch only when composition cannot express the requirement.
+6. Never copy or independently reimplement an upstream product capability.
+
+Every delivery PR must answer:
+
+- Which upstream capability is reused?
+- Why is each new Edge-owned code path not expressible by composition alone?
+- Did the PR add or retain a package patch, and what removes it?
+
+## Credential invariant update
+
+The v0.3 invariant "Never persist or log `DEEPSEEK_API_KEY`" is replaced by:
+
+> Provider credentials persist only through the upstream `CredentialProvider` seam in Durable Object storage; resolved values remain request-scoped in the LLM adapter and are never logged, cached across requests, or written to session events.
+
+This enables the upstream Settings → Models page to accept API keys at runtime while maintaining the request-scoped resolution contract that upstream consumers depend on.
+
+## Scope
+
+### Included
+
+- Writable `EdgeCredentialProvider` with DO KV storage and Worker env fallback.
+- Upstream `dsh-settings` integration via a `DurableObjectSettingsProvider`.
+- Registration of the `llm-pi-ai` settings namespace for provider configuration.
+- `ApiProxy` settings wiring so the upstream Models page UI works unchanged.
+- Dynamic LLM adapter registration from settings-stored provider definitions.
+- Installer simplification: `DEEPSEEK_API_KEY` becomes optional at deployment.
+- Bilingual documentation updates.
+
+### Excluded
+
+- Auth delegation to Durable Object (deferred; access key changes require a separate architectural change).
+- OAuth and interactive authorization flows (`ctx.authorization`).
+- Non-OpenAI-compatible API protocols (native Anthropic Messages API, Bedrock, Vertex).
+- Credential record storage (`readRecord`, `modifyRecord`).
+- A second credential UI, provider form, or model catalog owned by dsh-edge.
+
+## Delivery stages
+
+| Stage | Delivery | Exit criteria | Status |
+| --- | --- | --- | --- |
+| 1 | Writable credentials with DO storage | `set`/`unset` persist to DO KV; `resolve` checks DO first then Worker env; existing deployments keep working; tests pass | In progress |
+| 2 | Upstream Settings integration | `DurableObjectSettingsProvider` implements `load`/`persist`; `llm-pi-ai` namespace registered; `ApiProxy` settings wired to real implementation; upstream Models page opens and reads current provider | Planned |
+| 3 | Multi-provider adapter registration | Provider config read from settings; adapters registered dynamically; model selection works across providers; a second provider can be added from the Models page and used in a conversation | Planned |
+| 4 | Documentation and release | Bilingual docs updated; installer simplified; browser snapshots updated; `0.4.0-alpha.1` prepared | Planned |
+
+Each stage is normally one reviewable PR.
+
+## Stage 1 evidence
+
+### Upstream reuse
+
+- `EdgeCredentialProvider` extends `@deepseek-ai/dsh-credentials/CredentialProvider` — the same abstract seam used by upstream `dsh-credentials-local`.
+- The `resolve`/`describe`/`set`/`unset` contract matches upstream semantics: per-operation resolution, empty values treated as absent, source-layer reporting.
+- `dsh-settings` v0.1.1-rc.1 is already installed and partially bundled (schemastery shared by 11 packages).
+
+### Edge-owned code
+
+- `DurableObjectStorage` KV is the persistence medium because no filesystem or `dsh-settings-file` is available in Workers.
+- The storage key prefix `dsh-edge:credential:` follows the same naming convention as `dsh-edge:workspace-domain-state:` and `dsh-edge:session-model:`.
+- Worker env fallback is Edge-specific: upstream providers resolve from env vars, files, or project/user env layers; Edge collapses this to one env fallback.
+
+### Backward compatibility
+
+- Existing deployments that set `DEEPSEEK_API_KEY` via `wrangler secret put` continue to work: `resolve()` falls back to Worker env when DO KV is empty.
+- `describe()` now reports `writable: true` instead of `false`. This change enables the upstream Models page to show the "Save" button for credentials. Old clients that don't call `set()` are unaffected.
+
+## Progress log
+
+| Date | Change | Evidence / next action |
+| --- | --- | --- |
+| 2026-08-22 | Stage 1 started | EdgeCredentialProvider made writable with DO KV + Worker env fallback; AGENTS.md invariant updated; unit tests cover priority, fallback, set/unset round-trip, empty-value rejection; Stage 2 is next |

--- a/.agents/notes/implemented/architecture/2026-08-22-dsh-edge-v0.4-multi-provider-vision.zh.md
+++ b/.agents/notes/implemented/architecture/2026-08-22-dsh-edge-v0.4-multi-provider-vision.zh.md
@@ -1,0 +1,92 @@
+# Agent Note: dsh-edge 0.4 多 Provider 愿景
+
+状态：进行中 — Stage 1 开发中
+
+[English](2026-08-22-dsh-edge-v0.4-multi-provider-vision.md) | 中文
+
+## 目标
+
+dsh-edge 0.4 增加运行时可配置的 LLM Provider 和可写凭证，用户可以在浏览器的 Settings 页面添加 Anthropic、OpenAI 和自定义 OpenAI 兼容 Provider，无需重新部署。上游 Settings 子系统、Models 页面 UI 和凭证提供者接缝负责 Provider 管理；dsh-edge 组合一个 Durable Object 存储后端用于设置持久化和凭证存储。
+
+现有部署完全向后兼容：Worker 环境变量中的密钥继续作为降级来源生效，无需迁移。
+
+## 不可协商的所有权边界
+
+对于每项能力，按以下优先级使用，并记录为何需要更低层级的选择：
+
+1. 原样使用已发布的上游包、插件、UI、协议、Schema 和默认目录。
+2. 组合上游服务/提供者/插件槽位。
+3. 在上游接口后实现最小的 Edge 自有适配器。
+4. 仅为 Cloudflare 特定的产品状态或操作添加 `ui-edge` 贡献。
+5. 仅在组合无法表达需求时应用精确版本的包补丁。
+6. 绝不复制或独立重新实现上游产品能力。
+
+每个交付 PR 必须回答：
+
+- 复用了哪个上游能力？
+- 为什么每条新的 Edge 自有代码路径不能仅通过组合表达？
+- PR 是否增减了包补丁，以及什么条件移除它？
+
+## 凭证不变量更新
+
+v0.3 的不变量"绝不持久化或记录 `DEEPSEEK_API_KEY`"被替换为：
+
+> Provider 凭证仅通过上游 `CredentialProvider` 接缝持久化到 Durable Object 存储；解析值在 LLM 适配器中保持请求级作用域，绝不记录、跨请求缓存或写入会话事件。
+
+这使得上游 Settings → Models 页面能在运行时接受 API Key，同时维持上游消费者依赖的请求级解析契约。
+
+## 范围
+
+### 包含
+
+- 可写的 `EdgeCredentialProvider`，使用 DO KV 存储和 Worker 环境变量降级。
+- 通过 `DurableObjectSettingsProvider` 集成上游 `dsh-settings`。
+- 注册 `llm-pi-ai` Settings 命名空间用于 Provider 配置。
+- `ApiProxy` settings 接线，使上游 Models 页面 UI 无需修改即可工作。
+- 从 settings 存储的 Provider 定义动态注册 LLM 适配器。
+- 安装流程简化：`DEEPSEEK_API_KEY` 在部署时变为可选。
+- 双语文档更新。
+
+### 排除
+
+- 认证下沉到 Durable Object（延后；Access Key 变更需要独立的架构改动）。
+- OAuth 和交互式授权流程（`ctx.authorization`）。
+- 非 OpenAI 兼容的 API 协议（原生 Anthropic Messages API、Bedrock、Vertex）。
+- 凭证记录存储（`readRecord`、`modifyRecord`）。
+- dsh-edge 自有的第二套凭证 UI、Provider 表单或模型目录。
+
+## 交付阶段
+
+| 阶段 | 交付 | 退出标准 | 状态 |
+| --- | --- | --- | --- |
+| 1 | 可写凭证与 DO 存储 | `set`/`unset` 持久化到 DO KV；`resolve` 先查 DO 再查 Worker env；现有部署继续工作；测试通过 | 进行中 |
+| 2 | 上游 Settings 集成 | `DurableObjectSettingsProvider` 实现 `load`/`persist`；`llm-pi-ai` 命名空间已注册；`ApiProxy` settings 接通真实实现；上游 Models 页面能打开并读取当前 Provider | 计划中 |
+| 3 | 多 Provider 适配器注册 | 从 settings 读取 Provider 配置；动态注册适配器；跨 Provider 模型选择工作；可从 Models 页面添加第二个 Provider 并在对话中使用 | 计划中 |
+| 4 | 文档与发布 | 双语文档更新；安装流程简化；浏览器快照更新；准备 `0.4.0-alpha.1` | 计划中 |
+
+每个阶段通常是一个可审查的 PR。
+
+## Stage 1 证据
+
+### 上游复用
+
+- `EdgeCredentialProvider` 继承自 `@deepseek-ai/dsh-credentials/CredentialProvider`——与上游 `dsh-credentials-local` 使用的相同抽象接缝。
+- `resolve`/`describe`/`set`/`unset` 契约匹配上游语义：每操作解析、空值视为缺失、源层报告。
+- `dsh-settings` v0.1.1-rc.1 已安装且部分打包（schemastery 被 11 个包共用）。
+
+### Edge 自有代码
+
+- `DurableObjectStorage` KV 是持久化介质，因为 Workers 中没有文件系统或 `dsh-settings-file`。
+- 存储键前缀 `dsh-edge:credential:` 遵循与 `dsh-edge:workspace-domain-state:` 和 `dsh-edge:session-model:` 相同的命名约定。
+- Worker 环境变量降级是 Edge 特有的：上游 Provider 从环境变量、文件或项目/用户环境层解析；Edge 将此折叠为一个环境变量降级。
+
+### 向后兼容
+
+- 已通过 `wrangler secret put` 设置 `DEEPSEEK_API_KEY` 的现有部署继续工作：`resolve()` 在 DO KV 为空时降级到 Worker 环境变量。
+- `describe()` 现在报告 `writable: true` 而非 `false`。此变更使上游 Models 页面显示凭证的"保存"按钮。不调用 `set()` 的旧客户端不受影响。
+
+## 进度日志
+
+| 日期 | 变更 | 证据 / 下一步 |
+| --- | --- | --- |
+| 2026-08-22 | Stage 1 开始 | EdgeCredentialProvider 改为可写，使用 DO KV + Worker env 降级；AGENTS.md 不变量已更新；单元测试覆盖优先级、降级、set/unset 往返、空值拒绝；Stage 2 为下一步 |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,7 @@ The root and standalone lockfiles serve different purposes. The root lock instal
 - Keep every `@deepseek-ai/dsh-*` standalone dependency on one exact upstream version. Upgrade it only in an explicit upstream-baseline PR.
 - Keep Direct and Dynamic Loader modes behaviorally aligned except for their command-execution backend and Cloudflare plan requirement.
 - Preserve Durable Object class names, bindings, session/event formats, workspace/VFS state, owner authentication, and public HTTP/WebSocket behavior unless an Agent Note explicitly changes them.
-- Never persist or log `DEEPSEEK_API_KEY`, `DSH_EDGE_ACCESS_KEY`, bearer tokens, or owner cookies. Provider credentials remain request-scoped.
+- Never log `DSH_EDGE_ACCESS_KEY`, bearer tokens, or owner cookies. Provider credentials persist only through the upstream `CredentialProvider` seam in Durable Object storage; resolved values remain request-scoped in the LLM adapter and are never logged, cached across requests, or written to session events.
 - Direct mode must stay below the repository gzip budget. Release tests must start the promoted prebuilt artifacts, not source entrypoints.
 - Every retained upstream patch needs a version-bound filename, a failing-without-the-patch check, a rationale, and a removal condition.
 - The npm package, tag, GitHub Release, deployment identity, and documentation must report the same dsh-edge version.

--- a/apps/dsh-edge/src/edge-api.ts
+++ b/apps/dsh-edge/src/edge-api.ts
@@ -60,6 +60,8 @@ export interface EdgeApiRuntime {
   readonly imageLimits?: ImageAttachmentLimits
   deploymentProfile(): EdgeDeploymentProfile
   describeCredential(ref: string): Promise<CredentialView>
+  setCredential(ref: string, value: string): Promise<void>
+  unsetCredential(ref: string): Promise<void>
   isRunning(sessionId: SessionId): boolean
   prompt(input: {
     sessionId: SessionId
@@ -636,8 +638,32 @@ export function createEdgeApi(runtime: EdgeApiRuntime): ApiProxy {
         )))
         return ok(request, { credentials: Object.fromEntries(entries) })
       },
-      set: unsupported,
-      unset: unsupported,
+      async set(request) {
+        const { ref, value } = request.payload
+        try {
+          await runtime.setCredential(ref, value)
+          return ok(request, {})
+        } catch (error) {
+          return fail(request, {
+            code: 'internal',
+            message: error instanceof Error ? error.message : String(error),
+            details: {},
+          })
+        }
+      },
+      async unset(request) {
+        const { ref } = request.payload
+        try {
+          await runtime.unsetCredential(ref)
+          return ok(request, {})
+        } catch (error) {
+          return fail(request, {
+            code: 'internal',
+            message: error instanceof Error ? error.message : String(error),
+            details: {},
+          })
+        }
+      },
     },
 
     llm: {

--- a/apps/dsh-edge/src/edge-credentials.ts
+++ b/apps/dsh-edge/src/edge-credentials.ts
@@ -1,4 +1,4 @@
-/** Read-only upstream credential provider over Cloudflare Worker secrets. */
+/** Upstream credential provider over Cloudflare Worker secrets and Durable Object storage. */
 
 import type { Context } from '@deepseek-ai/cordis'
 import CredentialProvider, {
@@ -14,46 +14,63 @@ import CredentialProvider, {
 
 export const EDGE_DEEPSEEK_API_KEY_REF = credentialRef('DEEPSEEK_API_KEY')
 
+const CREDENTIAL_STORAGE_KEY_PREFIX = 'dsh-edge:credential:'
+
 export interface EdgeCredentialProviderConfig {
-  /** Read the current deployment secret without copying it into Durable Object storage. */
+  /** Durable Object storage for runtime-writable credentials. */
+  storage: DurableObjectStorage
+  /** Read the current deployment secret as an immutable fallback. */
   readDeepSeekApiKey(): string | undefined
 }
 
-/** Resolve deployment credentials through the same seam used by upstream providers. */
+/** Resolve credentials from Durable Object storage with Worker environment fallback. */
 export class EdgeCredentialProvider extends CredentialProvider {
+  private readonly storage: DurableObjectStorage
+
   constructor(
     ctx: Context,
     private readonly config: EdgeCredentialProviderConfig,
   ) {
     super(ctx)
+    this.storage = config.storage
   }
 
-  /** Resolve the supported Worker secret for one operation. */
-  override resolve(ref: CredentialRef): Promise<ResolvedCredential | undefined> {
-    if (ref !== EDGE_DEEPSEEK_API_KEY_REF) return Promise.resolve(undefined)
-    const value = this.config.readDeepSeekApiKey()?.trim()
-    if (value === undefined || value.length === 0) return Promise.resolve(undefined)
-    return Promise.resolve({ value, source: 'worker-secret' })
+  /** Resolve one credential: DO storage first, then Worker env fallback for DEEPSEEK_API_KEY. */
+  override async resolve(ref: CredentialRef): Promise<ResolvedCredential | undefined> {
+    const stored = await this.storage.get<string>(storageKey(ref))
+    if (typeof stored === 'string' && stored.trim().length > 0) {
+      return { value: stored.trim(), source: 'do-storage' }
+    }
+    if (ref === EDGE_DEEPSEEK_API_KEY_REF) {
+      const value = this.config.readDeepSeekApiKey()?.trim()
+      if (value !== undefined && value.length > 0) {
+        return { value, source: 'worker-secret' }
+      }
+    }
+    return undefined
   }
 
-  /** Describe a Worker secret without exposing its value. */
+  /** Describe a credential without exposing its value. */
   override async describe(ref: CredentialRef): Promise<CredentialInfo> {
     const resolved = await this.resolve(ref)
     return {
       configured: resolved !== undefined,
       ...resolved === undefined ? {} : { source: resolved.source },
-      writable: false,
+      writable: true,
     }
   }
 
-  /** Cloudflare secrets are changed through deployment tooling, not runtime RPCs. */
-  override set(_ref: CredentialRef, _value: string): Promise<void> {
-    return Promise.reject(new Error('dsh-edge credentials are read-only; update the Cloudflare Worker secret.'))
+  /** Store a credential in Durable Object storage. */
+  override async set(ref: CredentialRef, value: string): Promise<void> {
+    if (value.trim().length === 0) {
+      throw new Error('Credential value must not be empty.')
+    }
+    await this.storage.put(storageKey(ref), value)
   }
 
-  /** Cloudflare secrets are changed through deployment tooling, not runtime RPCs. */
-  override unset(_ref: CredentialRef): Promise<void> {
-    return Promise.reject(new Error('dsh-edge credentials are read-only; update the Cloudflare Worker secret.'))
+  /** Remove a credential from Durable Object storage. */
+  override async unset(ref: CredentialRef): Promise<void> {
+    await this.storage.delete(storageKey(ref))
   }
 
   /** Edge currently exposes deployment-secret references, not provider-owned authorization records. */
@@ -85,6 +102,10 @@ export class EdgeCredentialProvider extends CredentialProvider {
   override deleteRecord(_key: CredentialKey): Promise<void> {
     return Promise.resolve()
   }
+}
+
+function storageKey(ref: CredentialRef): string {
+  return CREDENTIAL_STORAGE_KEY_PREFIX + ref
 }
 
 export default EdgeCredentialProvider

--- a/apps/dsh-edge/src/instance.ts
+++ b/apps/dsh-edge/src/instance.ts
@@ -208,6 +208,8 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
       : EDGE_R2_IMAGE_LIMITS,
     deploymentProfile: () => resolveEdgeDeploymentProfile(this.env, this.attachmentStorage),
     describeCredential: ref => this.sessions.describeCredential(ref),
+    setCredential: (ref, value) => this.sessions.setCredential(ref, value),
+    unsetCredential: ref => this.sessions.unsetCredential(ref),
     isRunning: sessionId => this.activeTurns.has(sessionId),
     prompt: input => this.startApiPrompt(input),
     updateQueue: (sessionId, itemId, action) => this.updateQueue(sessionId, itemId, action),

--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -246,6 +246,18 @@ export class EdgeSessionStore {
     return await this.context.credentials.describe(credentialRef(ref))
   }
 
+  /** Persist one credential through the mounted upstream provider. */
+  async setCredential(ref: string, value: string): Promise<void> {
+    await this.ready
+    await this.context.credentials.set(credentialRef(ref), value)
+  }
+
+  /** Remove one credential from the mounted upstream provider. */
+  async unsetCredential(ref: string): Promise<void> {
+    await this.ready
+    await this.context.credentials.unset(credentialRef(ref))
+  }
+
   /** Project the registered upstream provider catalog into the upstream Web wire shape. */
   async modelCatalog(): Promise<{
     groups: ModelProviderGroup[]

--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -174,6 +174,7 @@ export class EdgeSessionStore {
           bucket: requireAttachmentBucket(config.attachmentBucket),
         }))
     await this.context.plugin(EdgeCredentialProvider, {
+      storage,
       readDeepSeekApiKey: () => config.readDeepSeekApiKey(),
     })
     await this.context.plugin(LlmRuntime)

--- a/apps/dsh-edge/tests/edge-api.spec.ts
+++ b/apps/dsh-edge/tests/edge-api.spec.ts
@@ -135,8 +135,10 @@ function runtime(
       },
     }),
     describeCredential: vi.fn(async ref => ref === 'DEEPSEEK_API_KEY'
-      ? { configured: true, source: 'worker-secret', writable: false }
-      : { configured: false, writable: false }),
+      ? { configured: true, source: 'worker-secret', writable: true }
+      : { configured: false, writable: true }),
+    setCredential: vi.fn(async () => {}),
+    unsetCredential: vi.fn(async () => {}),
     isRunning: () => false,
     prompt: vi.fn(async () => {}),
     updateQueue: vi.fn(() => 'accepted' as const),
@@ -205,20 +207,20 @@ describe('Edge upstream API invariants', () => {
       ok: true,
       value: {
         credentials: {
-          DEEPSEEK_API_KEY: { configured: true, source: 'worker-secret', writable: false },
-          OTHER_KEY: { configured: false, writable: false },
+          DEEPSEEK_API_KEY: { configured: true, source: 'worker-secret', writable: true },
+          OTHER_KEY: { configured: false, writable: true },
         },
       },
     })
 
     const unconfigured = await createEdgeApi(runtime({}, {
-      describeCredential: vi.fn(async () => ({ configured: false, writable: false })),
+      describeCredential: vi.fn(async () => ({ configured: false, writable: true })),
     })).credentials.describe(request({ refs: ['DEEPSEEK_API_KEY'] }))
     expect(unconfigured.result).toEqual({
       ok: true,
       value: {
         credentials: {
-          DEEPSEEK_API_KEY: { configured: false, writable: false },
+          DEEPSEEK_API_KEY: { configured: false, writable: true },
         },
       },
     })

--- a/apps/dsh-edge/tests/edge-credentials.spec.ts
+++ b/apps/dsh-edge/tests/edge-credentials.spec.ts
@@ -5,11 +5,21 @@ import EdgeCredentialProvider, {
   EDGE_DEEPSEEK_API_KEY_REF,
 } from '../src/edge-credentials.ts'
 
+function createMockStorage(): DurableObjectStorage {
+  const store = new Map<string, unknown>()
+  return {
+    get: (key: string) => Promise.resolve(store.get(key)),
+    put: (key: string, value: unknown) => { store.set(key, value); return Promise.resolve() },
+    delete: (key: string) => { store.delete(key); return Promise.resolve(true) },
+  } as unknown as DurableObjectStorage
+}
+
 describe('dsh-edge credential provider', () => {
-  it('resolves the current Worker secret without making it writable', async () => {
+  it('resolves from worker env when DO storage is empty', async () => {
     const ctx = new Context()
     let apiKey: string | undefined = 'first-key'
-    await ctx.plugin(EdgeCredentialProvider, { readDeepSeekApiKey: () => apiKey })
+    const storage = createMockStorage()
+    await ctx.plugin(EdgeCredentialProvider, { storage, readDeepSeekApiKey: () => apiKey })
     try {
       expect(await ctx.credentials.resolve(EDGE_DEEPSEEK_API_KEY_REF)).toEqual({
         value: 'first-key',
@@ -18,7 +28,7 @@ describe('dsh-edge credential provider', () => {
       expect(await ctx.credentials.describe(EDGE_DEEPSEEK_API_KEY_REF)).toEqual({
         configured: true,
         source: 'worker-secret',
-        writable: false,
+        writable: true,
       })
 
       apiKey = 'rotated-key'
@@ -37,26 +47,114 @@ describe('dsh-edge credential provider', () => {
       expect(await ctx.credentials.resolve(EDGE_DEEPSEEK_API_KEY_REF)).toBeUndefined()
       expect(await ctx.credentials.describe(EDGE_DEEPSEEK_API_KEY_REF)).toEqual({
         configured: false,
-        writable: false,
+        writable: true,
       })
     } finally {
       await ctx.fiber.dispose()
     }
   })
 
-  it('reports unsupported and absent references without creating a store', async () => {
+  it('resolves unknown refs from DO storage only', async () => {
     const ctx = new Context()
-    await ctx.plugin(EdgeCredentialProvider, { readDeepSeekApiKey: () => undefined })
+    const storage = createMockStorage()
+    await ctx.plugin(EdgeCredentialProvider, { storage, readDeepSeekApiKey: () => 'env-key' })
     try {
-      expect(await ctx.credentials.resolve(credentialRef('OTHER_KEY'))).toBeUndefined()
+      const otherRef = credentialRef('OTHER_KEY')
+      expect(await ctx.credentials.resolve(otherRef)).toBeUndefined()
+
+      await ctx.credentials.set(otherRef, 'stored-other')
+      expect(await ctx.credentials.resolve(otherRef)).toEqual({
+        value: 'stored-other',
+        source: 'do-storage',
+      })
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('prefers DO storage over worker env when both exist', async () => {
+    const ctx = new Context()
+    const storage = createMockStorage()
+    await ctx.plugin(EdgeCredentialProvider, { storage, readDeepSeekApiKey: () => 'env-key' })
+    try {
+      await ctx.credentials.set(EDGE_DEEPSEEK_API_KEY_REF, 'do-key')
+      expect(await ctx.credentials.resolve(EDGE_DEEPSEEK_API_KEY_REF)).toEqual({
+        value: 'do-key',
+        source: 'do-storage',
+      })
+      expect(await ctx.credentials.describe(EDGE_DEEPSEEK_API_KEY_REF)).toEqual({
+        configured: true,
+        source: 'do-storage',
+        writable: true,
+      })
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('falls back to worker env after DO storage value is unset', async () => {
+    const ctx = new Context()
+    const storage = createMockStorage()
+    await ctx.plugin(EdgeCredentialProvider, { storage, readDeepSeekApiKey: () => 'env-key' })
+    try {
+      await ctx.credentials.set(EDGE_DEEPSEEK_API_KEY_REF, 'do-key')
+      expect(await ctx.credentials.resolve(EDGE_DEEPSEEK_API_KEY_REF)).toEqual({
+        value: 'do-key',
+        source: 'do-storage',
+      })
+
+      await ctx.credentials.unset(EDGE_DEEPSEEK_API_KEY_REF)
+      expect(await ctx.credentials.resolve(EDGE_DEEPSEEK_API_KEY_REF)).toEqual({
+        value: 'env-key',
+        source: 'worker-secret',
+      })
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('rejects set with empty value', async () => {
+    const ctx = new Context()
+    const storage = createMockStorage()
+    await ctx.plugin(EdgeCredentialProvider, { storage, readDeepSeekApiKey: () => undefined })
+    try {
+      await expect(ctx.credentials.set(EDGE_DEEPSEEK_API_KEY_REF, ''))
+        .rejects.toThrow(/empty/u)
+      await expect(ctx.credentials.set(EDGE_DEEPSEEK_API_KEY_REF, '   '))
+        .rejects.toThrow(/empty/u)
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('describes unconfigured when neither DO nor env has a value', async () => {
+    const ctx = new Context()
+    const storage = createMockStorage()
+    await ctx.plugin(EdgeCredentialProvider, { storage, readDeepSeekApiKey: () => undefined })
+    try {
       expect(await ctx.credentials.describe(EDGE_DEEPSEEK_API_KEY_REF)).toEqual({
         configured: false,
-        writable: false,
+        writable: true,
       })
-      await expect(ctx.credentials.set(EDGE_DEEPSEEK_API_KEY_REF, 'new-key'))
-        .rejects.toThrow(/read-only/u)
-      await expect(ctx.credentials.unset(EDGE_DEEPSEEK_API_KEY_REF))
-        .rejects.toThrow(/read-only/u)
+      expect(await ctx.credentials.describe(credentialRef('OTHER_KEY'))).toEqual({
+        configured: false,
+        writable: true,
+      })
+    } finally {
+      await ctx.fiber.dispose()
+    }
+  })
+
+  it('treats stored empty string as absent', async () => {
+    const ctx = new Context()
+    const storage = createMockStorage()
+    await storage.put('dsh-edge:credential:DEEPSEEK_API_KEY', '  ')
+    await ctx.plugin(EdgeCredentialProvider, { storage, readDeepSeekApiKey: () => 'env-key' })
+    try {
+      expect(await ctx.credentials.resolve(EDGE_DEEPSEEK_API_KEY_REF)).toEqual({
+        value: 'env-key',
+        source: 'worker-secret',
+      })
     } finally {
       await ctx.fiber.dispose()
     }

--- a/apps/dsh-edge/tests/session.integration.mjs
+++ b/apps/dsh-edge/tests/session.integration.mjs
@@ -493,7 +493,7 @@ try {
   assert.deepEqual(credential.body.result.value.credentials.DEEPSEEK_API_KEY, {
     configured: true,
     source: 'worker-secret',
-    writable: false,
+    writable: true,
   })
   await new Promise(resolve => { setTimeout(resolve, 2_500) })
 

--- a/apps/dsh-edge/tests/web-search.spec.ts
+++ b/apps/dsh-edge/tests/web-search.spec.ts
@@ -24,7 +24,8 @@ describe('dsh-edge Web Search composition', () => {
 
     const ctx = new Context()
     try {
-      await ctx.plugin(EdgeCredentialProvider, { readDeepSeekApiKey: () => 'search-key' })
+      const storage = { get: () => Promise.resolve(undefined), put: () => Promise.resolve(), delete: () => Promise.resolve(true) } as unknown as DurableObjectStorage
+      await ctx.plugin(EdgeCredentialProvider, { storage, readDeepSeekApiKey: () => 'search-key' })
       await ctx.plugin(SystemPrompt)
       await ctx.plugin(ToolRuntime)
       await installEdgeWebSearch(ctx, 'https://search.test/anthropic/v1')


### PR DESCRIPTION
## Summary
- EdgeCredentialProvider now reads from DO KV with Worker env fallback
- `set()`/`unset()` write to DO KV instead of rejecting
- `describe()` reports `writable: true` and correct source layer
- Agent Note defines v0.4 multi-provider vision and 4 delivery stages
- AGENTS.md credential invariant updated to allow DO-stored credentials

## Upstream reuse
- `EdgeCredentialProvider` extends `@deepseek-ai/dsh-credentials/CredentialProvider` — same abstract seam as upstream `dsh-credentials-local`
- `resolve`/`describe`/`set`/`unset` contract matches upstream semantics

## Backward compatibility
- Existing deployments with `DEEPSEEK_API_KEY` in Worker env continue working (fallback)
- No migration required

## Test plan
- [x] 7 credential unit tests pass (priority, fallback, set/unset, empty-value, describe)
- [x] web-search test updated with storage mock
- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] `pnpm run build` passes
- [x] All 255 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCv5sH2zgBsQnpTM1z9mUy