### PR TITLE
feat(edge): register LLM providers dynamically from DO storage

### DIFF
--- a/apps/dsh-edge/src/edge-api.ts
+++ b/apps/dsh-edge/src/edge-api.ts
@@ -74,6 +74,14 @@ export interface EdgeApiRuntime {
   updateSettings(ns: string, patch: object, expectedRevision?: number): Promise<SettingsDescriptor | undefined>
   replaceSettings(ns: string, section: object, expectedRevision?: number): Promise<SettingsDescriptor | undefined>
   mutateSettings(ns: string, ops: readonly SettingsPathOp[], expectedRevision?: number): Promise<SettingsDescriptor | undefined>
+  listConfigurableProviders(): Promise<{
+    provider: string
+    displayName: string
+    settingsNs: string
+    settingsPath: readonly string[]
+    active: boolean
+    declared?: boolean
+  }[]>
   isRunning(sessionId: SessionId): boolean
   prompt(input: {
     sessionId: SessionId
@@ -717,16 +725,28 @@ export function createEdgeApi(runtime: EdgeApiRuntime): ApiProxy {
     },
 
     llm: {
-      providers: request => Promise.resolve(ok(request, {
-        providers: [{
-          provider: EDGE_PROVIDER,
-          displayName: 'DeepSeek',
-          settingsNs: 'llm-deepseek',
-          settingsPath: [],
-          active: true,
-          declared: false,
-        }],
-      })),
+      async providers(request) {
+        const configurable = await runtime.listConfigurableProviders()
+        const providers = [
+          {
+            provider: EDGE_PROVIDER,
+            displayName: 'DeepSeek',
+            settingsNs: 'llm-deepseek',
+            settingsPath: [] as string[],
+            active: true,
+            declared: false,
+          },
+          ...configurable.map(entry => ({
+            provider: entry.provider,
+            displayName: entry.displayName,
+            settingsNs: entry.settingsNs,
+            settingsPath: [...entry.settingsPath],
+            active: entry.active,
+            ...entry.declared === undefined ? {} : { declared: entry.declared },
+          })),
+        ]
+        return ok(request, { providers })
+      },
       async models(request) {
         return ok(request, await runtime.sessions.modelCatalog())
       },

--- a/apps/dsh-edge/src/edge-provider-manager.ts
+++ b/apps/dsh-edge/src/edge-provider-manager.ts
@@ -126,4 +126,12 @@ function isValidProviderEntry(value: unknown): value is EdgeProviderEntry {
     && typeof entry['baseURL'] === 'string' && entry['baseURL'].length > 0
     && typeof entry['apiKeyRef'] === 'string'
     && Array.isArray(entry['models'])
+    && entry['models'].every(isValidModelEntry)
+}
+
+function isValidModelEntry(value: unknown): value is { id: string; name: string } {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const model = value as Record<string, unknown>
+  return typeof model['id'] === 'string' && model['id'].length > 0
+    && typeof model['name'] === 'string' && model['name'].length > 0
 }

--- a/apps/dsh-edge/src/edge-provider-manager.ts
+++ b/apps/dsh-edge/src/edge-provider-manager.ts
@@ -38,7 +38,8 @@ export async function writeConfiguredProviders(
   storage: DurableObjectStorage,
   providers: EdgeProviderEntry[],
 ): Promise<void> {
-  await storage.put(PROVIDERS_STORAGE_KEY, providers)
+  const validated = providers.filter(isValidProviderEntry)
+  await storage.put(PROVIDERS_STORAGE_KEY, validated)
 }
 
 /** Register configured providers as LLM adapters on the cordis context. */

--- a/apps/dsh-edge/src/edge-provider-manager.ts
+++ b/apps/dsh-edge/src/edge-provider-manager.ts
@@ -31,7 +31,7 @@ export async function readConfiguredProviders(
 ): Promise<EdgeProviderEntry[]> {
   const stored = await storage.get(PROVIDERS_STORAGE_KEY)
   if (!Array.isArray(stored)) return []
-  return stored.filter(isValidProviderEntry)
+  return deduplicateProviders(stored.filter(isValidProviderEntry))
 }
 
 /** Persist configured providers to Durable Object storage. */
@@ -39,8 +39,17 @@ export async function writeConfiguredProviders(
   storage: DurableObjectStorage,
   providers: EdgeProviderEntry[],
 ): Promise<void> {
-  const validated = providers.filter(isValidProviderEntry)
+  const validated = deduplicateProviders(providers.filter(isValidProviderEntry))
   await storage.put(PROVIDERS_STORAGE_KEY, validated)
+}
+
+function deduplicateProviders(entries: EdgeProviderEntry[]): EdgeProviderEntry[] {
+  const seen = new Set<string>()
+  return entries.filter(entry => {
+    if (seen.has(entry.id)) return false
+    seen.add(entry.id)
+    return true
+  })
 }
 
 /** Register configured providers as LLM adapters on the cordis context. */

--- a/apps/dsh-edge/src/edge-provider-manager.ts
+++ b/apps/dsh-edge/src/edge-provider-manager.ts
@@ -1,0 +1,129 @@
+/** Dynamic LLM provider registration from Durable Object storage. */
+
+import type { Context } from '@deepseek-ai/cordis'
+import type { AttachmentStore } from '@deepseek-ai/dsh-attachment'
+import type { CredentialRef } from '@deepseek-ai/dsh-credentials'
+import {
+  LlmError,
+  assertUsableApiKey,
+} from '@deepseek-ai/dsh-llm'
+import {
+  DeepSeekAdapter,
+  resolveAdapterOptions,
+} from '@deepseek-ai/dsh-llm-deepseek'
+import type { AnonymousUserId } from '@deepseek-ai/dsh-anonymous-user-id'
+
+const PROVIDERS_STORAGE_KEY = 'dsh-edge:configured-providers'
+
+/** One user-configured LLM provider stored in DO KV. */
+export interface EdgeProviderEntry {
+  id: string
+  name: string
+  baseURL: string
+  apiKeyRef: string
+  models: { id: string; name: string }[]
+}
+
+/** Read configured providers from Durable Object storage. */
+export async function readConfiguredProviders(
+  storage: DurableObjectStorage,
+): Promise<EdgeProviderEntry[]> {
+  const stored = await storage.get(PROVIDERS_STORAGE_KEY)
+  if (!Array.isArray(stored)) return []
+  return stored.filter(isValidProviderEntry)
+}
+
+/** Persist configured providers to Durable Object storage. */
+export async function writeConfiguredProviders(
+  storage: DurableObjectStorage,
+  providers: EdgeProviderEntry[],
+): Promise<void> {
+  await storage.put(PROVIDERS_STORAGE_KEY, providers)
+}
+
+/** Register configured providers as LLM adapters on the cordis context. */
+export function installConfiguredProviders(
+  ctx: Context,
+  entries: readonly EdgeProviderEntry[],
+  resolveAttachments?: () => AttachmentStore | undefined,
+): () => void {
+  const disposers: (() => void)[] = []
+
+  for (const entry of entries) {
+    if (entry.id.length === 0 || entry.baseURL.length === 0) continue
+    const adapter = createProviderAdapter(ctx, entry, resolveAttachments)
+    const handle = ctx.llm.registerAdapter([entry.id], adapter)
+    disposers.push(handle)
+  }
+
+  let configurableDispose: (() => void) | undefined
+  const configurableEntries = entries
+    .filter(entry => entry.id.length > 0 && entry.baseURL.length > 0)
+    .map(entry => ({
+      provider: entry.id,
+      displayName: entry.name || entry.id,
+      settingsNs: 'edge-providers',
+      settingsPath: ['providers'] as readonly string[],
+      declared: true as const,
+    }))
+
+  if (configurableEntries.length > 0) {
+    try {
+      const handle = ctx.llm.registerConfigurableProviders(configurableEntries)
+      configurableDispose = handle
+    } catch {
+      // Advisory; failure does not block turns.
+    }
+  }
+
+  return () => {
+    for (const dispose of disposers) dispose()
+    configurableDispose?.()
+  }
+}
+
+function createProviderAdapter(
+  ctx: Context,
+  entry: EdgeProviderEntry,
+  resolveAttachments?: () => AttachmentStore | undefined,
+): DeepSeekAdapter {
+  const ref = (entry.apiKeyRef || `${entry.id.toUpperCase().replace(/[^A-Z0-9]/g, '_')}_API_KEY`) as CredentialRef
+  const connection = resolveAdapterOptions({
+    apiKeyEnv: ref,
+    baseURL: entry.baseURL,
+  })
+  const anonymousRequestId = crypto.randomUUID() as AnonymousUserId
+  return new DeepSeekAdapter({
+    options: () => ({
+      ...connection,
+      models: entry.models.map(m => ({
+        id: m.id,
+        ...m.name ? { name: m.name } : {},
+      })),
+    }),
+    resolveApiKey: async () => {
+      const resolved = await ctx.credentials.resolve(ref)
+      if (resolved === undefined) {
+        throw new LlmError(
+          `dsh-edge: no API key for provider "${entry.id}"; store ${String(ref)} through the credentials service`,
+          'MISSING_CREDENTIAL',
+        )
+      }
+      return assertUsableApiKey(resolved.value, 'dsh-edge', ref)
+    },
+    resolveUserId: () => anonymousRequestId,
+    ...resolveAttachments === undefined
+      ? {}
+      : { resolveAttachments },
+  })
+}
+
+function isValidProviderEntry(value: unknown): value is EdgeProviderEntry {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
+  const entry = value as Record<string, unknown>
+  return typeof entry['id'] === 'string' && entry['id'].length > 0
+    && typeof entry['name'] === 'string'
+    && typeof entry['baseURL'] === 'string' && entry['baseURL'].length > 0
+    && typeof entry['apiKeyRef'] === 'string'
+    && Array.isArray(entry['models'])
+}

--- a/apps/dsh-edge/src/edge-provider-manager.ts
+++ b/apps/dsh-edge/src/edge-provider-manager.ts
@@ -124,9 +124,21 @@ function isValidProviderEntry(value: unknown): value is EdgeProviderEntry {
   return typeof entry['id'] === 'string' && entry['id'].length > 0
     && typeof entry['name'] === 'string'
     && typeof entry['baseURL'] === 'string' && entry['baseURL'].length > 0
+    && isCredentialFreeHttpUrl(entry['baseURL'])
     && typeof entry['apiKeyRef'] === 'string'
     && Array.isArray(entry['models'])
     && entry['models'].every(isValidModelEntry)
+}
+
+function isCredentialFreeHttpUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value)
+    return (parsed.protocol === 'http:' || parsed.protocol === 'https:')
+      && parsed.username.length === 0
+      && parsed.password.length === 0
+  } catch {
+    return false
+  }
 }
 
 function isValidModelEntry(value: unknown): value is { id: string; name: string } {

--- a/apps/dsh-edge/src/edge-provider-manager.ts
+++ b/apps/dsh-edge/src/edge-provider-manager.ts
@@ -49,7 +49,10 @@ function deduplicateProviders(entries: EdgeProviderEntry[]): EdgeProviderEntry[]
     if (seen.has(entry.id)) return false
     seen.add(entry.id)
     return true
-  })
+  }).map(entry => ({
+    ...entry,
+    models: deduplicateModels(entry.models),
+  }))
 }
 
 /** Register configured providers as LLM adapters on the cordis context. */
@@ -148,9 +151,20 @@ function isCredentialFreeHttpUrl(value: string): boolean {
     return (parsed.protocol === 'http:' || parsed.protocol === 'https:')
       && parsed.username.length === 0
       && parsed.password.length === 0
+      && parsed.search.length === 0
+      && parsed.hash.length === 0
   } catch {
     return false
   }
+}
+
+function deduplicateModels(models: { id: string; name: string }[]): { id: string; name: string }[] {
+  const seen = new Set<string>()
+  return models.filter(model => {
+    if (seen.has(model.id)) return false
+    seen.add(model.id)
+    return true
+  })
 }
 
 function isValidModelEntry(value: unknown): value is { id: string; name: string } {

--- a/apps/dsh-edge/src/edge-provider-manager.ts
+++ b/apps/dsh-edge/src/edge-provider-manager.ts
@@ -14,6 +14,7 @@ import {
 import type { AnonymousUserId } from '@deepseek-ai/dsh-anonymous-user-id'
 
 const PROVIDERS_STORAGE_KEY = 'dsh-edge:configured-providers'
+const RESERVED_PROVIDER_ID = 'deepseek-official'
 
 /** One user-configured LLM provider stored in DO KV. */
 export interface EdgeProviderEntry {
@@ -123,6 +124,7 @@ function isValidProviderEntry(value: unknown): value is EdgeProviderEntry {
   if (typeof value !== 'object' || value === null || Array.isArray(value)) return false
   const entry = value as Record<string, unknown>
   return typeof entry['id'] === 'string' && entry['id'].length > 0
+    && entry['id'] !== RESERVED_PROVIDER_ID
     && typeof entry['name'] === 'string'
     && typeof entry['baseURL'] === 'string' && entry['baseURL'].length > 0
     && isCredentialFreeHttpUrl(entry['baseURL'])

--- a/apps/dsh-edge/src/instance.ts
+++ b/apps/dsh-edge/src/instance.ts
@@ -216,6 +216,7 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
     updateSettings: (ns, patch, rev) => this.sessions.updateSettings(ns, patch, rev),
     replaceSettings: (ns, section, rev) => this.sessions.replaceSettings(ns, section, rev),
     mutateSettings: (ns, ops, rev) => this.sessions.mutateSettings(ns, ops, rev),
+    listConfigurableProviders: () => this.sessions.listConfigurableProviders(),
     isRunning: sessionId => this.activeTurns.has(sessionId),
     prompt: input => this.startApiPrompt(input),
     updateQueue: (sessionId, itemId, action) => this.updateQueue(sessionId, itemId, action),

--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -62,6 +62,10 @@ import {
 } from '@deepseek-ai/dsh-settings'
 import DurableObjectSettingsProvider from './do-settings-provider.ts'
 import EdgeCredentialProvider, { EDGE_DEEPSEEK_API_KEY_REF } from './edge-credentials.ts'
+import {
+  installConfiguredProviders,
+  readConfiguredProviders,
+} from './edge-provider-manager.ts'
 import DurableObjectSessionPersistence, {
   EDGE_HISTORY_PAGE_LIMITS,
   type EdgeEventPage,
@@ -196,6 +200,17 @@ export class EdgeSessionStore {
       () => this.context.llm.registerAdapter([EDGE_PROVIDER], this.model),
       'dsh-edge: model adapter',
     )
+    const configuredProviders = await readConfiguredProviders(storage)
+    if (configuredProviders.length > 0) {
+      this.context.effect(
+        () => installConfiguredProviders(
+          this.context,
+          configuredProviders,
+          () => this.context.get('attachments'),
+        ),
+        'dsh-edge: configured providers',
+      )
+    }
     this.context.effect(
       () => this.context.tools.register(createEdgeBashTool(this.shells)),
       'dsh-edge: bash tool',
@@ -263,6 +278,27 @@ export class EdgeSessionStore {
   async unsetCredential(ref: string): Promise<void> {
     await this.ready
     await this.context.credentials.unset(credentialRef(ref))
+  }
+
+  /** List every configurable provider with its live/dormant state. */
+  async listConfigurableProviders(): Promise<{
+    provider: string
+    displayName: string
+    settingsNs: string
+    settingsPath: readonly string[]
+    active: boolean
+    declared?: boolean
+  }[]> {
+    await this.ready
+    const live = new Set(this.context.llm.listProviders().map(p => p.id))
+    return this.context.llm.listConfigurableProviders().map(entry => ({
+      provider: entry.provider,
+      displayName: entry.displayName,
+      settingsNs: entry.settingsNs,
+      settingsPath: [...entry.settingsPath],
+      active: live.has(entry.provider),
+      ...entry.declared === undefined ? {} : { declared: entry.declared },
+    }))
   }
 
   /** Whether the mounted settings provider accepts runtime writes. */

--- a/apps/dsh-edge/tests/edge-api.spec.ts
+++ b/apps/dsh-edge/tests/edge-api.spec.ts
@@ -145,6 +145,7 @@ function runtime(
     updateSettings: vi.fn(async () => undefined),
     replaceSettings: vi.fn(async () => undefined),
     mutateSettings: vi.fn(async () => undefined),
+    listConfigurableProviders: vi.fn(async () => []),
     isRunning: () => false,
     prompt: vi.fn(async () => {}),
     updateQueue: vi.fn(() => 'accepted' as const),

--- a/apps/dsh-edge/tests/edge-provider-manager.spec.ts
+++ b/apps/dsh-edge/tests/edge-provider-manager.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import {
+  readConfiguredProviders,
+  writeConfiguredProviders,
+  type EdgeProviderEntry,
+} from '../src/edge-provider-manager.ts'
+
+function createMockStorage(): DurableObjectStorage & { readonly store: Map<string, unknown> } {
+  const store = new Map<string, unknown>()
+  return {
+    store,
+    get: (key: string) => Promise.resolve(store.get(key)),
+    put: (key: string, value: unknown) => { store.set(key, value); return Promise.resolve() },
+    delete: (key: string) => { store.delete(key); return Promise.resolve(true) },
+  } as unknown as DurableObjectStorage & { readonly store: Map<string, unknown> }
+}
+
+const validProvider: EdgeProviderEntry = {
+  id: 'openai',
+  name: 'OpenAI',
+  baseURL: 'https://api.openai.com/v1',
+  apiKeyRef: 'OPENAI_API_KEY',
+  models: [{ id: 'gpt-4o', name: 'GPT-4o' }],
+}
+
+describe('EdgeProviderManager storage', () => {
+  it('reads empty array from fresh storage', async () => {
+    const storage = createMockStorage()
+    expect(await readConfiguredProviders(storage)).toEqual([])
+  })
+
+  it('round-trips a provider entry', async () => {
+    const storage = createMockStorage()
+    await writeConfiguredProviders(storage, [validProvider])
+    const result = await readConfiguredProviders(storage)
+    expect(result).toEqual([validProvider])
+  })
+
+  it('filters invalid entries on read', async () => {
+    const storage = createMockStorage()
+    storage.store.set('dsh-edge:configured-providers', [
+      validProvider,
+      { id: '', name: 'bad', baseURL: '', apiKeyRef: '', models: [] },
+      'not-an-object',
+      null,
+    ])
+    const result = await readConfiguredProviders(storage)
+    expect(result).toHaveLength(1)
+    expect(result[0]!.id).toBe('openai')
+  })
+
+  it('returns empty for non-array stored data', async () => {
+    const storage = createMockStorage()
+    storage.store.set('dsh-edge:configured-providers', 'not-an-array')
+    expect(await readConfiguredProviders(storage)).toEqual([])
+  })
+
+  it('preserves multiple providers', async () => {
+    const storage = createMockStorage()
+    const anthropic: EdgeProviderEntry = {
+      id: 'anthropic',
+      name: 'Anthropic',
+      baseURL: 'https://api.anthropic.com',
+      apiKeyRef: 'ANTHROPIC_API_KEY',
+      models: [{ id: 'claude-sonnet-5', name: 'Claude Sonnet 5' }],
+    }
+    await writeConfiguredProviders(storage, [validProvider, anthropic])
+    const result = await readConfiguredProviders(storage)
+    expect(result).toHaveLength(2)
+    expect(result[0]!.id).toBe('openai')
+    expect(result[1]!.id).toBe('anthropic')
+  })
+})


### PR DESCRIPTION
## Summary
- New `EdgeProviderManager` reads provider config from DO KV and registers adapters
- Each configured provider gets a `DeepSeekAdapter` (OpenAI-compatible) with its own credential resolution
- `llm.providers` endpoint now dynamically lists all configurable providers alongside DeepSeek
- `listConfigurableProviders()` added to `EdgeSessionStore` and wired through `EdgeApiRuntime`
- Provider storage contract: `readConfiguredProviders()` / `writeConfiguredProviders()`

## Test plan
- [ ] Provider storage round-trip (read/write/filter invalid)
- [ ] Empty storage returns empty array
- [ ] Multiple providers preserved
- [ ] Invalid entries filtered on read
- [ ] Default DeepSeek provider unaffected
- [ ] pnpm run check passes
- [ ] pnpm run build passes (both modes)
- [ ] 253 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01JCv5sH2zgBsQnpTM1z9mUy