### PR TITLE
feat(edge): make DEEPSEEK_API_KEY optional at install time

### DIFF
--- a/apps/dsh-edge/README.i18n.yaml
+++ b/apps/dsh-edge/README.i18n.yaml
@@ -2,5 +2,5 @@
 # last confirmed-consistent state. Both languages carry equal authority.
 # After editing either side, update both and re-record every pair with:
 #   pnpm run doc-pairs -- --write
-README.md: be20969e175ac2a1ac625efcd3faa5dcd181cb4f
-README.zh.md: cba63c2df8482c079b543e23c7182f40c938c27a
+README.md: 5a8966328b4b1b4eeaaa96e947d3550aa308f021
+README.zh.md: 435e6d7570bfdc2f4ecf4f78a6394734924ebf87

--- a/apps/dsh-edge/README.md
+++ b/apps/dsh-edge/README.md
@@ -221,7 +221,7 @@ npx dsh-edge install
 
 This resolves through npm's `latest` channel. Use `npx dsh-edge@next install` only to opt into a newer prerelease when one is available.
 
-Upgrade an existing named Worker with the same runtime choice. The deployment keeps its Durable Object data; because Cloudflare secrets are write-only, the upgrade asks for the owner access key and DeepSeek API key again and replaces their active values:
+Upgrade an existing named Worker with the same runtime choice. The deployment keeps its Durable Object data; because Cloudflare secrets are write-only, the upgrade asks for the owner access key again. The DeepSeek API key prompt is optional — press Enter to skip it and configure the key later through Settings → Models:
 
 For a stable deployment, run:
 

--- a/apps/dsh-edge/README.zh.md
+++ b/apps/dsh-edge/README.zh.md
@@ -221,7 +221,7 @@ npx dsh-edge install
 
 该命令通过 npm `latest` 渠道解析。只有在存在更新的预发布版且你想主动试用时，才使用 `npx dsh-edge@next install`。
 
-选择相同 runtime 并输入现有 Worker 名称即可升级。部署会保留 Durable Object 数据；由于 Cloudflare secret 只能写入而不能读取，升级会再次要求 owner access key 与 DeepSeek API key，并用输入值替换当前生效值：
+选择相同 runtime 并输入现有 Worker 名称即可升级。部署会保留 Durable Object 数据；由于 Cloudflare secret 只能写入而不能读取，升级会再次要求 owner access key。DeepSeek API key 提示为可选——直接按 Enter 跳过，稍后通过 Settings → Models 配置：
 
 稳定部署运行：
 

--- a/apps/dsh-edge/scripts/install.mjs
+++ b/apps/dsh-edge/scripts/install.mjs
@@ -231,7 +231,7 @@ export function validateOwnerSecret(value) {
 
 /** Validate a provider key without encoding assumptions that DeepSeek does not promise. */
 export function validateDeepSeekKey(value) {
-  if (value === '') return 'Enter a DeepSeek API key.'
+  if (value === '') return undefined
   if (value !== value.trim()) return 'The DeepSeek API key cannot start or end with whitespace.'
   if (CONTROL_CHARACTER.test(value)) return 'The DeepSeek API key cannot contain control characters.'
 }
@@ -685,7 +685,7 @@ export async function installEdge({
       ...bucketName === undefined ? {} : { r2BucketName: bucketName },
     })
     await writeFile(secretsFile, JSON.stringify({
-      DEEPSEEK_API_KEY: deepSeekKey,
+      ...deepSeekKey !== '' ? { DEEPSEEK_API_KEY: deepSeekKey } : {},
       DSH_EDGE_ACCESS_KEY: ownerSecret,
     }), { encoding: 'utf8', mode: 0o600, flag: 'wx' })
 

--- a/apps/dsh-edge/src/deployment.ts
+++ b/apps/dsh-edge/src/deployment.ts
@@ -8,7 +8,6 @@ import {
   resolveEdgeReasoningEffort,
   resolveEdgeStreamIdleTimeoutMs,
 } from './deepseek.ts'
-import { resolveDeepSeekApiKey } from './http.ts'
 import { resolveEdgeSearchBaseURL } from './web-search.ts'
 import {
   resolveEdgeCommandTimeoutPolicy,
@@ -70,11 +69,10 @@ export function resolveEdgeDeploymentId(): string {
     : LOCAL_DEPLOYMENT_ID
 }
 
-/** Resolve every deployment choice before health succeeds or a turn is claimed. */
+/** Resolve every deployment choice before a turn is claimed. */
 export function resolveEdgeDeploymentConfig(
   source: EdgeDeploymentConfigSource,
 ): EdgeDeploymentConfig {
-  resolveDeepSeekApiKey(source.DEEPSEEK_API_KEY)
   return {
     baseURL: resolveEdgeBaseURL(source.DEEPSEEK_BASE_URL),
     maxTokens: resolveEdgeMaxOutputTokens(source.DEEPSEEK_MAX_OUTPUT_TOKENS),

--- a/apps/dsh-edge/tests/deployment.spec.ts
+++ b/apps/dsh-edge/tests/deployment.spec.ts
@@ -116,7 +116,6 @@ describe('dsh-edge deployment configuration', () => {
   })
 
   it.each([
-    [{}, /Configure the DEEPSEEK_API_KEY Worker secret/u],
     [{ ...VALID_SOURCE, DEEPSEEK_BASE_URL: 'file:///tmp/model' }, /valid HTTP\(S\) URL/u],
     [{ ...VALID_SOURCE, DEEPSEEK_MAX_OUTPUT_TOKENS: '0' }, /positive integer/u],
     [{ ...VALID_SOURCE, DEEPSEEK_MODEL: 'bad model' }, /valid model id/u],
@@ -142,6 +141,13 @@ describe('dsh-edge deployment configuration', () => {
       ...VALID_SOURCE,
       DEEPSEEK_REASONING_EFFORT: 'low',
     }).reasoningEffort).toBe('low')
+  })
+
+  it('reports ready health without a deployment API key', () => {
+    const { DEEPSEEK_API_KEY: _, ...sourceWithoutKey } = VALID_SOURCE
+    const health = resolveEdgeDeploymentHealth(sourceWithoutKey)
+    expect(health.ok).toBe(true)
+    expect(health.status).toBe('ready')
   })
 
 })

--- a/apps/dsh-edge/tests/installer.spec.ts
+++ b/apps/dsh-edge/tests/installer.spec.ts
@@ -191,7 +191,7 @@ describe('dsh-edge installer primitives', () => {
     expect(validateOwnerSecret(`${OWNER_SECRET}\n`)).toContain('whitespace')
     expect(validateOwnerSecret(`${OWNER_SECRET}\u202E`)).toContain('bidirectional')
     expect(validateDeepSeekKey('sk-test')).toBeUndefined()
-    expect(validateDeepSeekKey('')).toContain('Enter')
+    expect(validateDeepSeekKey('')).toBeUndefined()
     expect(validateDeepSeekKey(' sk-test')).toContain('whitespace')
   })
 


### PR DESCRIPTION
## Summary
- `validateDeepSeekKey('')` now returns `undefined` (valid) instead of an error
- Installer skips setting `DEEPSEEK_API_KEY` Worker secret when empty
- Health endpoint no longer requires the key — `resolveEdgeDeploymentConfig` removed the `resolveDeepSeekApiKey` validation
- Bilingual README updated to note the key prompt is optional
- New test: health succeeds without a deployment API key

## Test plan
- [x] `validateDeepSeekKey('')` returns undefined
- [x] Health endpoint reports ready without API key
- [x] Existing key-provided install path unchanged (snapshot passes)
- [x] 261 unit tests pass
- [x] Typecheck clean
- [x] Build passes
- [x] Doc pairs consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)