### PR TITLE
feat(edge): installer Images optimization prompt + v0.5.1

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -56,8 +56,8 @@ Every version published to npm must also have a matching GitHub Release and git 
 
 1. **Merge the release PR** to main (squash merge).
 2. **Pull main** and verify `apps/dsh-edge/package.json` version matches the intended release.
-3. **Build**: `pnpm --filter dsh-edge run bundle:workers`.
-4. **Publish to npm**: `cd apps/dsh-edge && npm publish --ignore-scripts` (prepack already ran in step 3). Use `--tag next` for prereleases.
+3. **Build and verify**: `pnpm --filter dsh-edge run bundle:workers` then `pnpm --filter dsh-edge run legal:write` to ensure legal notices and worker artifacts are current.
+4. **Publish to npm**: `cd apps/dsh-edge && npm publish` (runs the prepack hook which re-verifies legal files and rebuilds). Use `--tag next` for prereleases.
 5. **Create a git tag**: `git tag dsh-edge-v<version>` on the merge commit.
 6. **Push the tag**: `git push origin dsh-edge-v<version>`.
 7. **Create a GitHub Release**: `gh release create dsh-edge-v<version> --title "dsh-edge <version>" --notes-file docs/releases/<version>.md`. Use `--prerelease` for alpha/rc versions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -50,4 +50,19 @@ Use `.agents/skills/dsh-pre-push-checks/SKILL.md` before a push and `.agents/ski
 
 Review rounds are convergence checkpoints, not a fixed retry budget. On repeated problem families, audit all affected callers and replace local patches with one invariant-preserving repair. Stop only for genuine scope decisions or non-convergence. Never merge automatically.
 
+## Release procedure
+
+Every version published to npm must also have a matching GitHub Release and git tag. Skipping any step breaks the invariant on line 36.
+
+1. **Merge the release PR** to main (squash merge).
+2. **Pull main** and verify `apps/dsh-edge/package.json` version matches the intended release.
+3. **Build**: `pnpm --filter dsh-edge run bundle:workers`.
+4. **Publish to npm**: `cd apps/dsh-edge && npm publish --ignore-scripts` (prepack already ran in step 3). Use `--tag next` for prereleases.
+5. **Create a git tag**: `git tag dsh-edge-v<version>` on the merge commit.
+6. **Push the tag**: `git push origin dsh-edge-v<version>`.
+7. **Create a GitHub Release**: `gh release create dsh-edge-v<version> --title "dsh-edge <version>" --notes-file docs/releases/<version>.md`. Use `--prerelease` for alpha/rc versions.
+8. **Verify**: `npm view dsh-edge@<version>` and `gh release view dsh-edge-v<version>` both resolve.
+
+Never publish to npm without completing steps 5–7 in the same session. If npm publish succeeds but GitHub Release fails, fix the GitHub Release immediately before moving on.
+
 Stage, commit, push, PR creation, review replies, thread resolution, releases, tags, npm publication, and Cloudflare deployment require the corresponding user authorization.

--- a/apps/dsh-edge/scripts/cli.mjs
+++ b/apps/dsh-edge/scripts/cli.mjs
@@ -222,6 +222,19 @@ export function createInstallerUi(
         validate,
       })))
     },
+    async enableImages(isTemporary) {
+      if (isTemporary) return false
+      const mode = await requireAnswer(await clack.select(withOutput({
+        message: 'Image optimization',
+        initialValue: 'enable',
+        signal,
+        options: [
+          { value: 'enable', label: 'Enable', hint: 'free 5,000 transforms/month' },
+          { value: 'skip', label: 'Skip' },
+        ],
+      })))
+      return mode === 'enable'
+    },
     async confirm(summary) {
       note([
         `Runtime: ${summary.modeLabel}`,

--- a/apps/dsh-edge/scripts/install.d.mts
+++ b/apps/dsh-edge/scripts/install.d.mts
@@ -30,6 +30,7 @@ export interface InstallerUi {
   selectOwnerSecretMode(): Promise<'generate' | 'custom'>
   ownerSecret(validate: (value: string) => string | undefined): Promise<string>
   deepSeekKey(validate: (value: string) => string | undefined): Promise<string>
+  enableImages(isTemporary: boolean): Promise<boolean>
   confirm(summary: {
     mode: RuntimeMode
     modeLabel: string

--- a/apps/dsh-edge/scripts/install.d.mts
+++ b/apps/dsh-edge/scripts/install.d.mts
@@ -30,7 +30,7 @@ export interface InstallerUi {
   selectOwnerSecretMode(): Promise<'generate' | 'custom'>
   ownerSecret(validate: (value: string) => string | undefined): Promise<string>
   deepSeekKey(validate: (value: string) => string | undefined): Promise<string>
-  enableImages(isTemporary: boolean): Promise<boolean>
+  enableImages?(isTemporary: boolean): Promise<boolean>
   confirm(summary: {
     mode: RuntimeMode
     modeLabel: string

--- a/apps/dsh-edge/scripts/install.mjs
+++ b/apps/dsh-edge/scripts/install.mjs
@@ -646,6 +646,7 @@ export async function installEdge({
     const deepSeekKey = await ui.deepSeekKey(validateDeepSeekKey)
     const deepSeekError = validateDeepSeekKey(deepSeekKey)
     if (deepSeekError !== undefined) throw new Error(deepSeekError)
+    const enableImages = await ui.enableImages(temporary)
 
     let bucketName
     if (attachmentStorage === 'private-r2') {
@@ -683,6 +684,7 @@ export async function installEdge({
     const outputFile = join(temporaryDirectory, 'wrangler-output.ndjson')
     await writePrebuiltModeWranglerConfig(mode, configFile, {
       ...bucketName === undefined ? {} : { r2BucketName: bucketName },
+      enableImages,
     })
     await writeFile(secretsFile, JSON.stringify({
       ...deepSeekKey !== '' ? { DEEPSEEK_API_KEY: deepSeekKey } : {},

--- a/apps/dsh-edge/scripts/install.mjs
+++ b/apps/dsh-edge/scripts/install.mjs
@@ -646,7 +646,9 @@ export async function installEdge({
     const deepSeekKey = await ui.deepSeekKey(validateDeepSeekKey)
     const deepSeekError = validateDeepSeekKey(deepSeekKey)
     if (deepSeekError !== undefined) throw new Error(deepSeekError)
-    const enableImages = await ui.enableImages(temporary)
+    const enableImages = typeof ui.enableImages === 'function'
+      ? await ui.enableImages(temporary)
+      : false
 
     let bucketName
     if (attachmentStorage === 'private-r2') {

--- a/apps/dsh-edge/scripts/install.mjs
+++ b/apps/dsh-edge/scripts/install.mjs
@@ -646,7 +646,7 @@ export async function installEdge({
     const deepSeekKey = await ui.deepSeekKey(validateDeepSeekKey)
     const deepSeekError = validateDeepSeekKey(deepSeekKey)
     if (deepSeekError !== undefined) throw new Error(deepSeekError)
-    const enableImages = typeof ui.enableImages === 'function'
+    const enableImages = !temporary && typeof ui.enableImages === 'function'
       ? await ui.enableImages(temporary)
       : false
 

--- a/apps/dsh-edge/scripts/wrangler-config-core.mjs
+++ b/apps/dsh-edge/scripts/wrangler-config-core.mjs
@@ -67,6 +67,10 @@ export function renderParsedPrebuiltModeWranglerConfig(mode, parsed, options = {
   config.no_bundle = true
   config.find_additional_modules = false
   applyAttachmentStorage(config, mode, options.r2BucketName)
+  if (options.enableImages) {
+    const target = mode === 'direct' ? config : config.env?.isolated
+    if (isRecord(target)) target.images = { binding: 'IMAGES' }
+  }
   return `${JSON.stringify(config, undefined, 2)}\n`
 }
 

--- a/apps/dsh-edge/scripts/wrangler-config.d.mts
+++ b/apps/dsh-edge/scripts/wrangler-config.d.mts
@@ -5,6 +5,7 @@ export interface WranglerConfigOptions {
   appDirectory?: string
   assetsDirectory?: string
   r2BucketName?: string
+  enableImages?: boolean
   sourceConfigPath?: string
 }
 

--- a/apps/dsh-edge/tests/installer.spec.ts
+++ b/apps/dsh-edge/tests/installer.spec.ts
@@ -1787,6 +1787,7 @@ function createUi({
     selectOwnerSecretMode,
     ownerSecret,
     deepSeekKey,
+    enableImages: vi.fn().mockResolvedValue(false),
     confirm,
     acceptTemporaryTerms: vi.fn().mockResolvedValue(acceptTemporaryTerms),
     cleanupFailure,

--- a/apps/dsh-edge/tests/installer.spec.ts
+++ b/apps/dsh-edge/tests/installer.spec.ts
@@ -340,6 +340,21 @@ describe('dsh-edge installer primitives', () => {
       no_bundle: true,
     })
 
+    const imagesDirectConfig = parseJsonRecord(renderPrebuiltModeWranglerConfig(
+      'direct', source, { appDirectory: root, enableImages: true },
+    ))
+    expect(imagesDirectConfig).toHaveProperty('images', { binding: 'IMAGES' })
+
+    const imagesIsolatedConfig = parseJsonRecord(renderPrebuiltModeWranglerConfig(
+      'isolated', source, { appDirectory: root, enableImages: true },
+    ))
+    expect((imagesIsolatedConfig.env as Record<string, unknown>)?.isolated).toHaveProperty('images', { binding: 'IMAGES' })
+
+    const noImagesConfig = parseJsonRecord(renderPrebuiltModeWranglerConfig(
+      'direct', source, { appDirectory: root },
+    ))
+    expect(noImagesConfig).not.toHaveProperty('images')
+
     const standalone = parseJsonRecord(renderSourceModeWranglerConfig('direct', source, {
       appDirectory: root,
       assetsDirectory: '/standalone/dist',


### PR DESCRIPTION
## Summary

- Installer prompts non-temporary users: "Image optimization — Enable (free 5,000 transforms/month) / Skip"
- When enabled, writes `IMAGES` binding to the deployed wrangler config
- Temporary accounts skip the prompt (Images not supported)
- Bumps version to 0.5.1

## Test plan

- [ ] CI passes
- [ ] `npx dsh-edge install` with a Cloudflare account shows the Images prompt
- [ ] `npx dsh-edge install` with temporary account skips the prompt

🤖 Generated with [Claude Code](https://claude.com/claude-code)