### PR TITLE
fix: persistent session event observer for async cordis plugins

### DIFF
--- a/apps/dsh-edge/src/instance.ts
+++ b/apps/dsh-edge/src/instance.ts
@@ -210,6 +210,7 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
       onLateSessionEvent: (sessionId, event) => {
         this.publishSessionEvent(sessionId, event)
       },
+      waitUntil: promise => this.ctx.waitUntil(promise),
     },
   )
   private readonly workspaces = new EdgeWorkspaceStore(this.ctx.storage)

--- a/apps/dsh-edge/src/instance.ts
+++ b/apps/dsh-edge/src/instance.ts
@@ -207,6 +207,9 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
       ...(this.env as unknown as Record<string, unknown>).IMAGES === undefined
         ? {}
         : { images: (this.env as unknown as Record<string, unknown>).IMAGES },
+      onLateSessionEvent: (sessionId, event) => {
+        this.publishSessionEvent(sessionId, event)
+      },
     },
   )
   private readonly workspaces = new EdgeWorkspaceStore(this.ctx.storage)

--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -92,6 +92,7 @@ interface EdgeSessionStoreConfig {
   reasoningEffort?: string
   streamIdleTimeoutMs?: string
   onLateSessionEvent?: (sessionId: SessionId, event: SessionEvent) => void
+  waitUntil?: (promise: Promise<unknown>) => void
 }
 const MAX_FORK_STORED_BYTES = 8 * 1_024 * 1_024
 const MAX_SEARCH_SESSIONS = 32
@@ -241,15 +242,17 @@ export class EdgeSessionStore {
     )
     if (config.onLateSessionEvent !== undefined) {
       const callback = config.onLateSessionEvent
+      const keepAlive = config.waitUntil
       this.context.on('session/event', (session, event) => {
         const agent = this.context.agents.get(session.id)
         if (agent?.session === session && this.turnPublishedAgents.has(agent)) return
         if (event.type === 'session/title' && event.data.source.kind === 'user') return
-        this.context.sessions.flush(session).then(() => {
+        const delivery = this.context.sessions.flush(session).then(() => {
           callback(session.id, event)
         }).catch((error: unknown) => {
           console.error('dsh-edge: failed to flush late session event.', error)
         })
+        keepAlive?.(delivery)
       })
     }
   }

--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -244,10 +244,12 @@ export class EdgeSessionStore {
       this.context.on('session/event', (session, event) => {
         const agent = this.context.agents.get(session.id)
         if (agent !== undefined && this.turnPublishedAgents.has(agent)) return
-        this.context.sessions.flush(session).catch((error: unknown) => {
+        if (event.type === 'session/title' && event.data.source.kind === 'user') return
+        this.context.sessions.flush(session).then(() => {
+          callback(session.id, event)
+        }).catch((error: unknown) => {
           console.error('dsh-edge: failed to flush late session event.', error)
         })
-        callback(session.id, event)
       })
     }
   }

--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -91,6 +91,7 @@ interface EdgeSessionStoreConfig {
   maxTokens?: string
   reasoningEffort?: string
   streamIdleTimeoutMs?: string
+  onLateSessionEvent?: (sessionId: SessionId, event: SessionEvent) => void
 }
 const MAX_FORK_STORED_BYTES = 8 * 1_024 * 1_024
 const MAX_SEARCH_SESSIONS = 32
@@ -238,6 +239,17 @@ export class EdgeSessionStore {
       () => this.context.tools.register(createEdgeBashTool(this.shells)),
       'dsh-edge: bash tool',
     )
+    if (config.onLateSessionEvent !== undefined) {
+      const callback = config.onLateSessionEvent
+      this.context.on('session/event', (session, event) => {
+        const agent = this.context.agents.get(session.id)
+        if (agent !== undefined && this.turnPublishedAgents.has(agent)) return
+        this.context.sessions.flush(session).catch((error: unknown) => {
+          console.error('dsh-edge: failed to flush late session event.', error)
+        })
+        callback(session.id, event)
+      })
+    }
   }
 
   /** Resolve the optional upstream attachment service composed for this deployment. */

--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -243,7 +243,7 @@ export class EdgeSessionStore {
       const callback = config.onLateSessionEvent
       this.context.on('session/event', (session, event) => {
         const agent = this.context.agents.get(session.id)
-        if (agent !== undefined && this.turnPublishedAgents.has(agent)) return
+        if (agent?.session === session && this.turnPublishedAgents.has(agent)) return
         if (event.type === 'session/title' && event.data.source.kind === 'user') return
         this.context.sessions.flush(session).then(() => {
           callback(session.id, event)


### PR DESCRIPTION
## Summary
- Add a persistent `session/event` observer to `EdgeSessionStore` that catches events arriving after the turn-scoped observer disconnects
- Fixes session title generation not appearing in the UI — the async auxiliary LLM call returns after the turn ends and its observer is gone
- Root cause: upstream runs as a long-lived Node process where sessions stay alive; Edge's DO disposes the turn observer when the turn completes
- Matches upstream's connection-scoped `ctx.on("session/event")` pattern in `dsh-host-apiproxy`
- During active turns, `turnPublishedAgents` prevents double-publishing; after turns end, the persistent observer handles flush + broadcast

## Test plan
- [x] `pnpm run check` — 262 tests pass + typecheck clean
- [ ] CI passes
- [ ] Deploy and verify: new session's first message triggers auto-generated title in sidebar

🤖 Generated with [Claude Code](https://claude.com/claude-code)