### PR TITLE
chore(release): bump dsh-edge to 0.5.1-alpha.2

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,11 +54,12 @@ Review rounds are convergence checkpoints, not a fixed retry budget. On repeated
 
 Every version published to npm must also have a matching GitHub Release and git tag. Skipping any step breaks the invariant on line 36.
 
-1. **Merge the release PR** to main (squash merge).
-2. **Pull main** and verify `apps/dsh-edge/package.json` version matches the intended release.
-3. **Create and push a git tag**: `git tag dsh-edge-v<version> && git push origin dsh-edge-v<version>`.
-4. The tag push triggers `release-edge.yml` which automatically builds, verifies, publishes to npm (trusted publishing), and creates the GitHub Release.
-5. **Verify**: `npm view dsh-edge@<version>` and `gh release view dsh-edge-v<version>` both resolve.
+1. **Write bilingual release notes**: create `docs/releases/<version>.md`, `docs/releases/<version>.zh.md`, and their `.i18n.yaml` pairing record, then run `pnpm run doc-pairs -- --write`.
+2. **Merge the release PR** to main (squash merge).
+3. **Pull main** and verify `apps/dsh-edge/package.json` version matches the intended release.
+4. **Create and push a git tag**: `git tag dsh-edge-v<version> && git push origin dsh-edge-v<version>`.
+5. The tag push triggers `release-edge.yml` which automatically builds, verifies, publishes to npm (trusted publishing), and creates the GitHub Release.
+6. **Verify**: `npm view dsh-edge@<version>` and `gh release view dsh-edge-v<version>` both resolve.
 
 The workflow can also be triggered manually via `request-release.yml` (workflow_dispatch) or `repository_dispatch` as a fallback. Prerelease versions (containing `-`) are published to the `next` npm dist-tag and marked as GitHub prerelease.
 

--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.5.1-alpha.1",
+  "version": "0.5.1-alpha.2",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.5.1-alpha.1.i18n.yaml
+++ b/docs/releases/0.5.1-alpha.1.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.5.1-alpha.1.md: a80ca464ce0da59fcee1d8e819abb71280fde413
+0.5.1-alpha.1.zh.md: a114b19a7c52373c2bfd152756037bf4edd2afe7

--- a/docs/releases/0.5.1-alpha.1.zh.md
+++ b/docs/releases/0.5.1-alpha.1.zh.md
@@ -1,0 +1,22 @@
+## dsh-edge 0.5.1-alpha.1
+
+测试 compaction、token meter 和 session title 插件的 Alpha 版本。
+
+### 新增
+
+- **上下文压缩**：通过上游 `BasicCompactionEngine` 和 `ToolResultPruner` cordis 插件实现自动上下文窗口压力检测和溢出恢复。长对话现在会压缩而非崩溃。
+- **Token 计量**：通过上游 `TokenMeter` 插件提供实时请求压力快照。
+- **Session 投影**：通过 `SessionProjectionRegistry` 提供上游基于 fold 的投影系统。
+- **自动 Session 标题**：首条用户消息通过 `SessionTitleService` 和 `FirstPromptTitle` 插件触发辅助 DeepSeek 调用生成标题。手动重命名仍然有效并锁定标题。
+
+### 变更
+
+- README 兼容性矩阵已更新，反映新启用的功能。
+- 集成测试和浏览器快照测试过滤辅助标题请求的计数。
+
+### 技术细节
+
+- 安装 7 个上游 cordis 插件，零 Edge 特定适配器。
+- 无需 `node:util` shim——Workers `nodejs_compat` 原生支持 `isDeepStrictEqual`。
+- 上游 `dsh-llm-deepseek` 已处理辅助调用（`purpose: 'compaction'`、`'session-title'`）。
+- Direct Worker gzip：~735KB/900KB 预算。

--- a/docs/releases/0.5.1-alpha.2.i18n.yaml
+++ b/docs/releases/0.5.1-alpha.2.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.5.1-alpha.2.md: 4e453f6c23acead0d3810ed579451be84fa8d8c3
+0.5.1-alpha.2.zh.md: f3509fcac649436fa42fa0fb69a6de4a80e4f307

--- a/docs/releases/0.5.1-alpha.2.md
+++ b/docs/releases/0.5.1-alpha.2.md
@@ -1,0 +1,11 @@
+## dsh-edge 0.5.1-alpha.2
+
+Fixes session title generation not appearing in the UI.
+
+### Fixed
+
+- Persistent session event observer for async cordis plugins (session title, compaction). Matches upstream's connection-scoped `ctx.on("session/event")` pattern.
+- Await flush before broadcasting late events.
+- Skip user-sourced titles to prevent duplicate broadcast with rename API.
+- Match session object identity in observer guard.
+- Keep late-event flush alive with `ctx.waitUntil`.

--- a/docs/releases/0.5.1-alpha.2.zh.md
+++ b/docs/releases/0.5.1-alpha.2.zh.md
@@ -1,0 +1,11 @@
+## dsh-edge 0.5.1-alpha.2
+
+修复 Session 标题生成不在 UI 中显示的问题。
+
+### 修复
+
+- 为异步 cordis 插件（session title、compaction）添加持久 `session/event` 观察者。匹配上游连接级 `ctx.on("session/event")` 模式。
+- 广播晚到事件前等待 flush 完成。
+- 跳过用户来源的标题以防止与 rename API 重复广播。
+- 在观察者守卫中匹配 session 对象标识。
+- 使用 `ctx.waitUntil` 保持晚到事件的 flush 存活。


### PR DESCRIPTION
## Summary
- Version bump to 0.5.1-alpha.2 for testing persistent event observer fix

## Test plan
- [ ] CI passes
- [ ] After merge: tag, publish, deploy, verify session title generation

🤖 Generated with [Claude Code](https://claude.com/claude-code)