### PR TITLE
chore(release): dsh-edge 0.5.1

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.5.1-alpha.2",
+  "version": "0.5.1",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.5.1.i18n.yaml
+++ b/docs/releases/0.5.1.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.5.1.md: 19a0fafc9691394674bda6cea28e92db89c40bd0
+0.5.1.zh.md: 2ec2e5fa552e44c9b27dd9ea510d4525427f96ba

--- a/docs/releases/0.5.1.md
+++ b/docs/releases/0.5.1.md
@@ -1,0 +1,22 @@
+## dsh-edge 0.5.1
+
+### Added
+
+- **Context compaction**: automatic context window pressure detection and overflow recovery via upstream `BasicCompactionEngine` and `ToolResultPruner` cordis plugins. Long conversations now compact instead of crashing with `CONTEXT_WINDOW_EXCEEDED`.
+- **Token meter**: real-time request pressure snapshots via upstream `TokenMeter` plugin, enabling proactive compaction triggers.
+- **Session projection**: upstream fold-based projection system via `SessionProjectionRegistry`.
+- **Automatic session titles**: first user message triggers title generation via an auxiliary DeepSeek call using `SessionTitleService` and `FirstPromptTitle` plugins. Manual rename still works and pins the title.
+- **Persistent session event observer**: matches upstream's connection-scoped `ctx.on("session/event")` pattern so async cordis plugins (title generation, compaction) can flush and broadcast events after a turn completes.
+
+### Changed
+
+- README compatibility matrices updated to reflect newly enabled capabilities.
+- Integration and browser snapshot tests filter auxiliary title requests from turn request accounting.
+- Release procedure now requires bilingual release notes as the first step.
+
+### Technical
+
+- 7 upstream cordis plugins installed with zero Edge-specific adapters (~25 LOC Edge, ~3,000 LOC upstream).
+- No `node:util` shim needed — Workers `nodejs_compat` supports `isDeepStrictEqual` natively.
+- Late events are flushed before broadcast and kept alive with `ctx.waitUntil`.
+- Direct Worker gzip: ~735KB/900KB budget.

--- a/docs/releases/0.5.1.zh.md
+++ b/docs/releases/0.5.1.zh.md
@@ -1,0 +1,22 @@
+## dsh-edge 0.5.1
+
+### 新增
+
+- **上下文压缩**：通过上游 `BasicCompactionEngine` 和 `ToolResultPruner` cordis 插件实现自动上下文窗口压力检测和溢出恢复。长对话现在会自动压缩而非崩溃。
+- **Token 计量**：通过上游 `TokenMeter` 插件提供实时请求压力快照，为主动压缩触发提供基础。
+- **Session 投影**：通过 `SessionProjectionRegistry` 提供上游基于 fold 的投影系统。
+- **自动 Session 标题**：首条用户消息通过 `SessionTitleService` 和 `FirstPromptTitle` 插件触发辅助 DeepSeek 调用生成标题。手动重命名仍然有效并锁定标题。
+- **持久 Session 事件观察者**：匹配上游连接级 `ctx.on("session/event")` 模式，确保异步 cordis 插件（标题生成、压缩）在对话轮次结束后仍能正确持久化和广播事件。
+
+### 变更
+
+- README 兼容性矩阵已更新，反映新启用的功能。
+- 集成测试和浏览器快照测试过滤辅助标题请求的计数。
+- 发版流程现在要求双语 release notes 作为第一步。
+
+### 技术细节
+
+- 安装 7 个上游 cordis 插件，零 Edge 特定适配器（~25 行 Edge 代码，~3,000 行上游代码复用）。
+- 无需 `node:util` shim——Workers `nodejs_compat` 原生支持 `isDeepStrictEqual`。
+- 晚到事件在广播前先 flush，并通过 `ctx.waitUntil` 保活。
+- Direct Worker gzip：~735KB/900KB 预算。


### PR DESCRIPTION
## Summary
- Promote 0.5.1-alpha.2 to stable 0.5.1
- Bilingual release notes included

### What's in 0.5.1
- Context compaction + token meter + tool result pruning
- Automatic session title generation
- Persistent session event observer for async cordis plugins

## Test plan
- [x] Alpha.2 deployed and verified by user
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)