### PR TITLE
chore(release): dsh-edge 0.5.2

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.5.2.i18n.yaml
+++ b/docs/releases/0.5.2.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.5.2.md: 0a94792885718ae98e77e02e11f2d4770b9d78a1
+0.5.2.zh.md: f226540f019188dc29f835bf4f85f62c5ee92f54

--- a/docs/releases/0.5.2.md
+++ b/docs/releases/0.5.2.md
@@ -1,0 +1,12 @@
+## dsh-edge 0.5.2
+
+### Added
+
+- **Spill storage**: oversized tool output (>32KB) is saved to `/workspace/.spill/` via Computer VFS instead of being permanently lost. The model receives a head/tail preview with a retrieval hint; the agent can `head`/`tail`/`grep` the spill file to recover complete content.
+- Upstream `dsh-spill` (seam), `dsh-spill-policy` (when to spill), and `dsh-output-retention` (preview generation) cordis plugins installed with a single Edge-specific provider (`EdgeVfsSpillStore`, ~35 LOC).
+
+### Technical
+
+- Reference-counted VFS binding supports concurrent turns in the same Durable Object.
+- Retrieval hints use chunked `head -c`/`tail -c` commands to avoid re-spilling on read.
+- Direct Worker gzip: ~737KB/900KB budget.

--- a/docs/releases/0.5.2.zh.md
+++ b/docs/releases/0.5.2.zh.md
@@ -1,0 +1,12 @@
+## dsh-edge 0.5.2
+
+### 新增
+
+- **Spill 存储**：超大工具输出（>32KB）保存到 `/workspace/.spill/`（通过 Computer VFS），不再永久丢失。模型收到头尾预览和取回提示；agent 可以用 `head`/`tail`/`grep` 读取 spill 文件恢复完整内容。
+- 安装上游 `dsh-spill`（seam）、`dsh-spill-policy`（触发策略）和 `dsh-output-retention`（预览生成）cordis 插件，仅需一个 Edge 特定 provider（`EdgeVfsSpillStore`，~35 行）。
+
+### 技术细节
+
+- 引用计数的 VFS 绑定支持同一 Durable Object 中的并发 turn。
+- 取回提示使用分块 `head -c`/`tail -c` 命令，避免读取时再次触发 spill。
+- Direct Worker gzip：~737KB/900KB 预算。


### PR DESCRIPTION
## Summary
- Spill storage: oversized tool output saved to VFS instead of lost
- Bilingual release notes included

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)