### PR TITLE
fix: materialize session summaries to eliminate correlated subquery row reads

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.5.2",
+  "version": "0.5.3",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/apps/dsh-edge/src/do-session-persistence.ts
+++ b/apps/dsh-edge/src/do-session-persistence.ts
@@ -616,6 +616,7 @@ export class DurableObjectSessionPersistence
       if (blank === undefined) return false
       if (this.rowFor(id) === undefined) this.writeRow(blank)
       this.storage.sql.exec('DELETE FROM dsh_edge_blank_sessions WHERE id = ?', id)
+      this.insertEmptyLogSummary(id, blank.createdAt)
       return true
     }))
   }
@@ -856,6 +857,17 @@ export class DurableObjectSessionPersistence
       titleSeq,
       titleTime,
       titleData,
+    )
+  }
+
+  private insertEmptyLogSummary(id: SessionId, createdAt: number): void {
+    this.storage.sql.exec(
+      `INSERT OR IGNORE INTO dsh_session_summaries
+        (session_id, revision, updated_at, last_prompt_at, last_seq, blank,
+         title_seq, title_time, title_data)
+       VALUES (?, 0, ?, NULL, -1, 1, NULL, NULL, NULL)`,
+      id,
+      createdAt,
     )
   }
 

--- a/apps/dsh-edge/src/do-session-persistence.ts
+++ b/apps/dsh-edge/src/do-session-persistence.ts
@@ -121,6 +121,7 @@ interface SessionSummaryRow extends HeaderRow {
   title_data: string | null
 }
 
+/** Expensive correlated-subquery summary; retained only for per-session recomputation. */
 const SESSION_SUMMARY_SELECT = `SELECT s.id, s.version, s.created_at, s.cwd, s.parent_session,
         s.seed_length, s.origin, s.delegation_depth, s.agent_preset, s.incarnation, s.revision,
         (SELECT e.time FROM dsh_session_events e
@@ -145,6 +146,13 @@ const SESSION_SUMMARY_SELECT = `SELECT s.id, s.version, s.created_at, s.cwd, s.p
          WHERE e.session_id = s.id AND e.type = 'session/title'
          ORDER BY e.seq DESC LIMIT 1) AS title_data
  FROM dsh_sessions s`
+
+const SESSION_SUMMARY_MATERIALIZED = `SELECT s.id, s.version, s.created_at, s.cwd, s.parent_session,
+        s.seed_length, s.origin, s.delegation_depth, s.agent_preset, s.incarnation, s.revision,
+        sm.updated_at, sm.last_prompt_at, sm.last_seq, sm.blank,
+        sm.title_seq, sm.title_time, sm.title_data
+ FROM dsh_sessions s
+ JOIN dsh_session_summaries sm ON s.id = sm.session_id`
 
 /** One cheap session-list item derived from canonical header/event rows. */
 export interface EdgeStoredSessionSummary {
@@ -450,6 +458,7 @@ export class DurableObjectSessionPersistence
         )
         if (updated.rowsWritten !== 1) throw new Error(`session ${meta.id} is not materialized`)
         this.storage.sql.exec('DELETE FROM dsh_edge_blank_sessions WHERE id = ?', meta.id)
+        this.updateSummaryFromBatch(meta.id, events)
       })
     })
   }
@@ -474,6 +483,7 @@ export class DurableObjectSessionPersistence
             'UPDATE dsh_sessions SET revision = revision + 1 WHERE id = ?',
             meta.id,
           )
+          this.recomputeSummary(meta.id)
         }
       })
     })
@@ -613,7 +623,7 @@ export class DurableObjectSessionPersistence
   /** Read one canonical header/title summary without materializing its event log. */
   readSessionSummary(id: SessionId): EdgeStoredSessionSummary | undefined {
     const row = this.storage.sql.exec<SessionSummaryRow>(
-      `${SESSION_SUMMARY_SELECT} WHERE s.id = ?`,
+      `${SESSION_SUMMARY_MATERIALIZED} WHERE s.id = ?`,
       id,
     ).toArray()[0]
     return row === undefined ? undefined : rowToStoredSessionSummary(row)
@@ -634,7 +644,7 @@ export class DurableObjectSessionPersistence
       if (cursor !== undefined) bindings.push(cursor.created_at, cursor.created_at, cursor.id)
       bindings.push(limit + 1)
       const rows = this.storage.sql.exec<SessionSummaryRow>(
-        `${SESSION_SUMMARY_SELECT} ${where}
+        `${SESSION_SUMMARY_MATERIALIZED} ${where}
          ORDER BY s.created_at DESC, s.id ASC LIMIT ?`,
         ...bindings,
       ).toArray()
@@ -648,16 +658,16 @@ export class DurableObjectSessionPersistence
   /** Read the upstream session-list baseline ordered by human activity. */
   readAllSessionSummaries(): EdgeStoredSessionSummary[] {
     return this.storage.sql.exec<SessionSummaryRow>(
-      `${SESSION_SUMMARY_SELECT}
-       ORDER BY coalesce(last_prompt_at, s.created_at) DESC, s.id ASC`,
+      `${SESSION_SUMMARY_MATERIALIZED}
+       ORDER BY coalesce(sm.last_prompt_at, s.created_at) DESC, s.id ASC`,
     ).toArray().map(rowToStoredSessionSummary)
   }
 
   /** Read only the newest canonical summaries needed by bounded consumers. */
   readRecentSessionSummaries(limit: number): EdgeStoredSessionSummary[] {
     return this.storage.sql.exec<SessionSummaryRow>(
-      `${SESSION_SUMMARY_SELECT}
-       ORDER BY coalesce(last_prompt_at, s.created_at) DESC, s.id ASC LIMIT ?`,
+      `${SESSION_SUMMARY_MATERIALIZED}
+       ORDER BY coalesce(sm.last_prompt_at, s.created_at) DESC, s.id ASC LIMIT ?`,
       limit,
     ).toArray().map(rowToStoredSessionSummary)
   }
@@ -724,8 +734,129 @@ export class DurableObjectSessionPersistence
         delegation_depth INTEGER,
         agent_preset TEXT
       ) STRICT`)
+      this.storage.sql.exec(`CREATE TABLE IF NOT EXISTS dsh_session_summaries (
+        session_id TEXT PRIMARY KEY REFERENCES dsh_sessions(id) ON DELETE CASCADE,
+        revision INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL,
+        last_prompt_at INTEGER,
+        last_seq INTEGER NOT NULL,
+        blank INTEGER NOT NULL,
+        title_seq INTEGER,
+        title_time INTEGER,
+        title_data TEXT
+      ) STRICT`)
+      this.syncSummaries()
       return `durable-object:store:${storeId}`
     })
+  }
+
+  private syncSummaries(): void {
+    const stale = this.storage.sql.exec<{ id: string }>(
+      `SELECT s.id FROM dsh_sessions s
+       LEFT JOIN dsh_session_summaries sm ON s.id = sm.session_id
+       WHERE sm.session_id IS NULL OR sm.revision != s.revision`,
+    ).toArray()
+    for (const row of stale) {
+      this.recomputeSummary(row.id as SessionId)
+    }
+  }
+
+  private recomputeSummary(id: SessionId): void {
+    const row = this.storage.sql.exec<SessionSummaryRow>(
+      `${SESSION_SUMMARY_SELECT} WHERE s.id = ?`,
+      id,
+    ).toArray()[0]
+    if (row === undefined) return
+    this.storage.sql.exec(
+      `INSERT INTO dsh_session_summaries
+        (session_id, revision, updated_at, last_prompt_at, last_seq, blank,
+         title_seq, title_time, title_data)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(session_id) DO UPDATE SET
+         revision = excluded.revision,
+         updated_at = excluded.updated_at,
+         last_prompt_at = excluded.last_prompt_at,
+         last_seq = excluded.last_seq,
+         blank = excluded.blank,
+         title_seq = excluded.title_seq,
+         title_time = excluded.title_time,
+         title_data = excluded.title_data`,
+      id,
+      row.revision,
+      row.updated_at ?? row.created_at,
+      row.last_prompt_at,
+      row.last_seq ?? -1,
+      row.blank ? 1 : 0,
+      row.title_seq,
+      row.title_time,
+      row.title_data,
+    )
+  }
+
+  private updateSummaryFromBatch(id: SessionId, events: readonly SessionEvent[]): void {
+    const lastEvent = events.at(-1)
+    if (lastEvent === undefined) return
+    const existing = this.storage.sql.exec<{
+      blank: number
+      last_prompt_at: number | null
+      title_seq: number | null
+      title_time: number | null
+      title_data: string | null
+    }>(
+      `SELECT blank, last_prompt_at, title_seq, title_time, title_data
+       FROM dsh_session_summaries WHERE session_id = ?`,
+      id,
+    ).toArray()[0]
+
+    let blank = existing?.blank ?? 1
+    let lastPromptAt: number | null = existing?.last_prompt_at ?? null
+    let titleSeq: number | null = existing?.title_seq ?? null
+    let titleTime: number | null = existing?.title_time ?? null
+    let titleData: string | null = existing?.title_data ?? null
+
+    for (const event of events) {
+      if (event.type === 'turn/start') blank = 0
+      if (event.type === 'user/message') {
+        const data = event.data as unknown as Record<string, unknown>
+        const source = data.source as Record<string, unknown> | undefined
+        if (source?.kind === 'user') lastPromptAt = event.time
+      }
+      if (event.type === 'session/title') {
+        titleSeq = event.seq
+        titleTime = event.time
+        titleData = JSON.stringify(event.data)
+      }
+    }
+
+    const rev = this.storage.sql.exec<{ revision: number }>(
+      'SELECT revision FROM dsh_sessions WHERE id = ?',
+      id,
+    ).toArray()[0]?.revision ?? 0
+
+    this.storage.sql.exec(
+      `INSERT INTO dsh_session_summaries
+        (session_id, revision, updated_at, last_prompt_at, last_seq, blank,
+         title_seq, title_time, title_data)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(session_id) DO UPDATE SET
+         revision = excluded.revision,
+         updated_at = excluded.updated_at,
+         last_prompt_at = excluded.last_prompt_at,
+         last_seq = excluded.last_seq,
+         blank = excluded.blank,
+         title_seq = excluded.title_seq,
+         title_time = excluded.title_time,
+         title_data = excluded.title_data`,
+      id,
+      rev,
+      lastEvent.time,
+      lastPromptAt,
+      lastEvent.seq,
+      blank,
+      titleSeq,
+      titleTime,
+      titleData,
+    )
   }
 
   private removePreCanonicalPrototype(): void {

--- a/apps/dsh-edge/tests/do-session-persistence.spec.ts
+++ b/apps/dsh-edge/tests/do-session-persistence.spec.ts
@@ -501,7 +501,7 @@ describe('durable-object bounded event pages', () => {
       expect(queries).toHaveLength(3)
       expect(queries[0]).toMatch(/FROM dsh_sessions WHERE id = \?/u)
       expect(queries[1]).toMatch(/FROM dsh_sessions WHERE id = \?/u)
-      expect(queries[2]).toMatch(/FROM dsh_sessions s WHERE s\.id = \?/u)
+      expect(queries[2]).toMatch(/FROM dsh_sessions s\b/u)
     } finally {
       await fiber.dispose()
       storage.close()
@@ -574,9 +574,15 @@ describe('durable-object bounded event pages', () => {
         { title: 'Title', messageSeqs: [], source: { kind: 'unknown' } },
       ]
       for (const payload of malformedPayloads) {
+        const raw = JSON.stringify(payload)
         storage.sql.exec(
           'UPDATE dsh_session_events SET data = ? WHERE session_id = ?',
-          JSON.stringify(payload),
+          raw,
+          id,
+        )
+        storage.sql.exec(
+          'UPDATE dsh_session_summaries SET title_data = ? WHERE session_id = ?',
+          raw,
           id,
         )
         expect(() => persistence.readSessionSummary(id))


### PR DESCRIPTION
## Summary
- Add `dsh_session_summaries` materialized table to pre-compute session metadata (updated_at, last_prompt_at, last_seq, blank, title), maintained atomically in `appendBatch()` and `commitRepair()`
- Replace `SESSION_SUMMARY_SELECT` (7 correlated subqueries per session row) with a simple JOIN for all hot read paths — `readAllSessionSummaries()`, `readRecentSessionSummaries()`, `readSessionSummary()`, `readSessionSummaryPage()`
- Reduces row reads by ~700× per `listApiSessions()` call (20 sessions × 200 events: ~28,000 → ~40 rows)
- Backward compatible: `DO_SESSION_SCHEMA_VERSION` stays at 2, table created with `CREATE TABLE IF NOT EXISTS`, revision-based stale detection with per-session recompute on init

Fixes free-tier "Exceeded allowed rows read in Durable Objects" caused by high-frequency `listApiSessions()` calls (page load, session create, workspace ops) running expensive correlated subqueries across all sessions.

## Test plan
- [x] All 249 unit tests pass
- [x] Integration tests pass (direct + isolated)
- [x] Pre-push typecheck pass
- [ ] Deploy and verify DO row reads drop on Cloudflare dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)