### PR TITLE
chore(release): dsh-edge 0.6.0-alpha.1

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.5.3",
+  "version": "0.6.0-alpha.1",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.6.0-alpha.1.i18n.yaml
+++ b/docs/releases/0.6.0-alpha.1.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.6.0-alpha.1.md: 11e39328199738249950634841e8b5fddfeaeca1
+0.6.0-alpha.1.zh.md: 8e75448335ca4bd930ee1956b593014cc7fddda2

--- a/docs/releases/0.6.0-alpha.1.i18n.yaml
+++ b/docs/releases/0.6.0-alpha.1.i18n.yaml
@@ -2,5 +2,5 @@
 # last confirmed-consistent state. Both languages carry equal authority.
 # After editing either side, update both and re-record every pair with:
 #   pnpm run doc-pairs -- --write
-0.6.0-alpha.1.md: 11e39328199738249950634841e8b5fddfeaeca1
-0.6.0-alpha.1.zh.md: 8e75448335ca4bd930ee1956b593014cc7fddda2
+0.6.0-alpha.1.md: 5435847103c13cdbd245127fb37f8aa9f58ccaad
+0.6.0-alpha.1.zh.md: e9ef39c21ecedadcbd5c6c9786a2471663b31004

--- a/docs/releases/0.6.0-alpha.1.md
+++ b/docs/releases/0.6.0-alpha.1.md
@@ -1,0 +1,21 @@
+## dsh-edge 0.6.0-alpha.1
+
+Alpha release for testing upstream WorkspaceRegistry and Storage subsystem.
+
+### Added
+
+- **DurableObjectStorageBackend**: maps upstream KV storage interface to DO `ctx.storage`, enabling any upstream `ctx.storageDomain` consumer.
+- **Upstream WorkspaceRegistry**: replaces the 339-LOC hand-rolled `EdgeWorkspaceStore` with the upstream cordis plugin. Unlocks multi-workspace support, CRUD, crash recovery, and schema alignment.
+- **Workspace data migration**: automatically migrates legacy `dsh-edge:workspace-domain-*` keys to the new `dsh-kv:` format on first boot. Preserves title, ordering, archived sessions, and stable workspace ID.
+
+### Removed
+
+- `EdgeWorkspaceStore` (339 LOC) — replaced by upstream.
+
+### Technical
+
+- Version-bound patch on `dsh-workspace` removes `node:fs/promises` dependency (realpath/stat not needed on VFS).
+- `ctx.provide()` bridges cordis inject with sub-registry backend registration.
+- WorkspaceRegistry `[Service.init]()` awaited via `internal/service` event before first access.
+- Default `/workspace` seeded only on genuinely new deployments (no persisted domain global).
+- Blank sessions included in `sessionPersistence.list()` for workspace header indexing.

--- a/docs/releases/0.6.0-alpha.1.md
+++ b/docs/releases/0.6.0-alpha.1.md
@@ -5,7 +5,7 @@ Alpha release for testing upstream WorkspaceRegistry and Storage subsystem.
 ### Added
 
 - **DurableObjectStorageBackend**: maps upstream KV storage interface to DO `ctx.storage`, enabling any upstream `ctx.storageDomain` consumer.
-- **Upstream WorkspaceRegistry**: replaces the 339-LOC hand-rolled `EdgeWorkspaceStore` with the upstream cordis plugin. Unlocks multi-workspace support, CRUD, crash recovery, and schema alignment.
+- **Upstream WorkspaceRegistry**: replaces the 339-LOC hand-rolled `EdgeWorkspaceStore` with the upstream cordis plugin. Enables workspace rename, reorder, archive, and crash recovery. Multi-workspace with distinct paths requires future session cwd propagation.
 - **Workspace data migration**: automatically migrates legacy `dsh-edge:workspace-domain-*` keys to the new `dsh-kv:` format on first boot. Preserves title, ordering, archived sessions, and stable workspace ID.
 
 ### Removed

--- a/docs/releases/0.6.0-alpha.1.zh.md
+++ b/docs/releases/0.6.0-alpha.1.zh.md
@@ -5,7 +5,7 @@
 ### 新增
 
 - **DurableObjectStorageBackend**：将上游 KV 存储接口映射到 DO `ctx.storage`，为所有上游 `ctx.storageDomain` 消费者提供基础。
-- **上游 WorkspaceRegistry**：用上游 cordis 插件替换 339 行手写的 `EdgeWorkspaceStore`。解锁多 workspace 支持、CRUD、崩溃恢复和 schema 对齐。
+- **上游 WorkspaceRegistry**：用上游 cordis 插件替换 339 行手写的 `EdgeWorkspaceStore`。支持 workspace 重命名、排序、归档和崩溃恢复。多 workspace 独立路径需要后续 session cwd 传播支持。
 - **Workspace 数据迁移**：首次启动时自动将旧格式 `dsh-edge:workspace-domain-*` key 迁移到新格式 `dsh-kv:`。保留标题、排序、归档 session 和稳定的 workspace ID。
 
 ### 移除

--- a/docs/releases/0.6.0-alpha.1.zh.md
+++ b/docs/releases/0.6.0-alpha.1.zh.md
@@ -1,0 +1,21 @@
+## dsh-edge 0.6.0-alpha.1
+
+测试上游 WorkspaceRegistry 和 Storage 子系统的 Alpha 版本。
+
+### 新增
+
+- **DurableObjectStorageBackend**：将上游 KV 存储接口映射到 DO `ctx.storage`，为所有上游 `ctx.storageDomain` 消费者提供基础。
+- **上游 WorkspaceRegistry**：用上游 cordis 插件替换 339 行手写的 `EdgeWorkspaceStore`。解锁多 workspace 支持、CRUD、崩溃恢复和 schema 对齐。
+- **Workspace 数据迁移**：首次启动时自动将旧格式 `dsh-edge:workspace-domain-*` key 迁移到新格式 `dsh-kv:`。保留标题、排序、归档 session 和稳定的 workspace ID。
+
+### 移除
+
+- `EdgeWorkspaceStore`（339 行）— 被上游替代。
+
+### 技术细节
+
+- 版本绑定 patch 移除 `dsh-workspace` 的 `node:fs/promises` 依赖。
+- `ctx.provide()` 桥接 cordis inject 和子注册表 backend 注册。
+- 通过 `internal/service` 事件等待 WorkspaceRegistry `[Service.init]()` 完成。
+- 默认 `/workspace` 仅在全新部署时创建（无持久化 domain global）。
+- `sessionPersistence.list()` 包含 blank sessions 用于 workspace header 索引。


### PR DESCRIPTION
## Summary
- Alpha for testing WorkspaceRegistry + Storage subsystem migration

## Test plan
- [ ] CI passes
- [ ] Deploy and verify: existing workspace data preserved, workspace CRUD works

🤖 Generated with [Claude Code](https://claude.com/claude-code)