### PR TITLE
release: dsh-edge 0.6.0-alpha.2

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0-alpha.2",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.6.0-alpha.2.i18n.yaml
+++ b/docs/releases/0.6.0-alpha.2.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.6.0-alpha.2.md: 1bb1e9f067881b20c5f516f1b3f338dff3b48036
+0.6.0-alpha.2.zh.md: f2f751fbfe609530f61f0ea3a9dee3a29ca9aa5c

--- a/docs/releases/0.6.0-alpha.2.md
+++ b/docs/releases/0.6.0-alpha.2.md
@@ -1,0 +1,21 @@
+## dsh-edge 0.6.0-alpha.2
+
+Alpha release adding multi-workspace session cwd propagation.
+
+### Added
+
+- **Workspace cwd propagation**: sessions created under a workspace now inherit its path as the working directory. The bash tool defaults to the session's cwd instead of hardcoded `/workspace`.
+- **Cwd validation**: caller-supplied cwd must be a valid path below `/workspace/`. Path traversal and non-workspace paths are rejected.
+- **Session cwd conflict detection**: reusing an existing session ID with a different cwd returns `session-conflict` with `requestedCwd`/`existingCwd` details.
+- **Multi-workspace integration tests**: second workspace creation, session cwd propagation, and invalid cwd rejection.
+
+### Changed
+
+- System prompt no longer references a hardcoded `/workspace` path. Each session's bash tool defaults to its own working directory.
+
+### Technical
+
+- `EdgeShellBindings` carries the session's cwd alongside the shell binding for per-session bash defaults.
+- `isValidWorkspacePath()` validates cwd at the RPC layer before persisting.
+- `rejectCwdConflict()` guards all three early-return branches in `createBlankSession`.
+- `EdgeSessionCwdConflictError` maps to upstream `session-conflict` RPC error code.

--- a/docs/releases/0.6.0-alpha.2.zh.md
+++ b/docs/releases/0.6.0-alpha.2.zh.md
@@ -1,0 +1,21 @@
+## dsh-edge 0.6.0-alpha.2
+
+新增多 workspace session 工作目录传播的 Alpha 版本。
+
+### 新增
+
+- **Workspace cwd 传播**：在某个 workspace 下创建的 session 会继承其路径作为工作目录。bash 工具默认使用 session 自身的 cwd，而非硬编码的 `/workspace`。
+- **Cwd 校验**：调用方提供的 cwd 必须是 `/workspace/` 下的合法路径。路径穿越和非 workspace 路径会被拒绝。
+- **Session cwd 冲突检测**：使用已有 session ID 但指定不同 cwd 时返回 `session-conflict` 错误，携带 `requestedCwd`/`existingCwd` 详情。
+- **多 workspace 集成测试**：覆盖第二个 workspace 创建、session cwd 传播、非法 cwd 拒绝。
+
+### 变更
+
+- 系统提示词不再引用硬编码的 `/workspace` 路径。每个 session 的 bash 工具默认使用其自身的工作目录。
+
+### 技术细节
+
+- `EdgeShellBindings` 在 shell 绑定中携带 session 的 cwd，实现按 session 的 bash 默认目录。
+- `isValidWorkspacePath()` 在 RPC 层持久化之前校验 cwd。
+- `rejectCwdConflict()` 守护 `createBlankSession` 中所有三个提前返回分支。
+- `EdgeSessionCwdConflictError` 映射到上游 `session-conflict` RPC 错误码。


### PR DESCRIPTION
## Summary

- Bump version to 0.6.0-alpha.2
- Bilingual release notes for workspace cwd propagation

## Changes in 0.6.0-alpha.2

- **Workspace cwd propagation**: sessions inherit workspace path as working directory
- **Cwd validation**: reject non-workspace paths and path traversal
- **Session cwd conflict detection**: `session-conflict` on reuse with different cwd
- **System prompt**: no longer hardcodes `/workspace`

## Test plan

- [ ] CI passes
- [ ] Merge, tag `dsh-edge-v0.6.0-alpha.2`, push tag
- [ ] Verify `npm view dsh-edge@0.6.0-alpha.2` resolves
- [ ] Test multi-workspace cwd with deployed instance

🤖 Generated with [Claude Code](https://claude.com/claude-code)