### PR TITLE
fix: repair epoch-0 workspace timestamps and add Edge directory picker

### DIFF
--- a/apps/dsh-edge/src/do-storage-backend.ts
+++ b/apps/dsh-edge/src/do-storage-backend.ts
@@ -191,8 +191,7 @@ export class DurableObjectStorageBackend implements StorageBackend {
       const segment = oldKey.slice(oldPrefix.length)
       const id = segment.endsWith(':v2') ? segment.slice(0, -3) : segment
       const record = value as Record<string, unknown>
-      if (record.createdAt === epoch0) record.createdAt = new Date().toISOString()
-      if (record.updatedAt === epoch0) record.updatedAt = new Date().toISOString()
+      repairEpoch0(record, epoch0)
       await storage.put(recordKey('workspace', 'workspaces', id), record)
       deleteKeys.push(oldKey)
     }
@@ -206,10 +205,21 @@ export class DurableObjectStorageBackend implements StorageBackend {
     for (const [key, value] of records) {
       const record = value as Record<string, unknown>
       if (record.createdAt !== epoch0 && record.updatedAt !== epoch0) continue
-      const now = new Date().toISOString()
-      if (record.createdAt === epoch0) record.createdAt = now
-      if (record.updatedAt === epoch0) record.updatedAt = now
+      repairEpoch0(record, epoch0)
       await storage.put(key, record)
     }
+  }
+}
+
+function repairEpoch0(record: Record<string, unknown>, epoch0: string): void {
+  if (record.createdAt !== epoch0 && record.updatedAt !== epoch0) return
+  if (record.updatedAt !== epoch0) {
+    record.createdAt = record.updatedAt
+  } else if (record.createdAt !== epoch0) {
+    record.updatedAt = record.createdAt
+  } else {
+    const now = new Date().toISOString()
+    record.createdAt = now
+    record.updatedAt = now
   }
 }

--- a/apps/dsh-edge/src/do-storage-backend.ts
+++ b/apps/dsh-edge/src/do-storage-backend.ts
@@ -199,6 +199,8 @@ export class DurableObjectStorageBackend implements StorageBackend {
   }
 
   static async repairEpoch0Timestamps(storage: DurableObjectStorage): Promise<void> {
+    const markerKey = 'dsh-edge:workspace-epoch0-repaired'
+    if (await storage.get(markerKey) === true) return
     const epoch0 = new Date(0).toISOString()
     const prefix = recordKey('workspace', 'workspaces', '')
     const records = await storage.list({ prefix })
@@ -208,6 +210,7 @@ export class DurableObjectStorageBackend implements StorageBackend {
       repairEpoch0(record, epoch0)
       await storage.put(key, record)
     }
+    await storage.put(markerKey, true)
   }
 }
 

--- a/apps/dsh-edge/src/do-storage-backend.ts
+++ b/apps/dsh-edge/src/do-storage-backend.ts
@@ -186,12 +186,30 @@ export class DurableObjectStorageBackend implements StorageBackend {
       })
     }
     await storage.put(versionKey('workspace'), 2)
+    const epoch0 = new Date(0).toISOString()
     for (const [oldKey, value] of oldRecords) {
       const segment = oldKey.slice(oldPrefix.length)
       const id = segment.endsWith(':v2') ? segment.slice(0, -3) : segment
-      await storage.put(recordKey('workspace', 'workspaces', id), value)
+      const record = value as Record<string, unknown>
+      if (record.createdAt === epoch0) record.createdAt = new Date().toISOString()
+      if (record.updatedAt === epoch0) record.updatedAt = new Date().toISOString()
+      await storage.put(recordKey('workspace', 'workspaces', id), record)
       deleteKeys.push(oldKey)
     }
     if (deleteKeys.length > 0) await storage.delete(deleteKeys)
+  }
+
+  static async repairEpoch0Timestamps(storage: DurableObjectStorage): Promise<void> {
+    const epoch0 = new Date(0).toISOString()
+    const prefix = recordKey('workspace', 'workspaces', '')
+    const records = await storage.list({ prefix })
+    for (const [key, value] of records) {
+      const record = value as Record<string, unknown>
+      if (record.createdAt !== epoch0 && record.updatedAt !== epoch0) continue
+      const now = new Date().toISOString()
+      if (record.createdAt === epoch0) record.createdAt = now
+      if (record.updatedAt === epoch0) record.updatedAt = now
+      await storage.put(key, record)
+    }
   }
 }

--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -214,6 +214,7 @@ export class EdgeSessionStore {
     })
     await this.context.plugin(DurableObjectSettingsProvider, { storage })
     await DurableObjectStorageBackend.migrateWorkspaceKeys(storage)
+    await DurableObjectStorageBackend.repairEpoch0Timestamps(storage)
     const storageBackend = new DurableObjectStorageBackend(storage)
     await this.context.plugin(Storage)
     this.context.effect(() => {

--- a/apps/dsh-edge/tests/do-storage-backend.spec.ts
+++ b/apps/dsh-edge/tests/do-storage-backend.spec.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+import { DurableObjectStorageBackend } from '../src/do-storage-backend.ts'
+
+const EPOCH_0 = new Date(0).toISOString()
+const REAL_TS = '2026-05-01T12:00:00.000Z'
+
+function createMockStorage(): DurableObjectStorage & { readonly store: Map<string, unknown> } {
+  const store = new Map<string, unknown>()
+  return {
+    store,
+    get: (key: string) => Promise.resolve(store.get(key)),
+    put: (key: string, value: unknown) => { store.set(key, value); return Promise.resolve() },
+    delete: (keys: string | string[]) => {
+      const arr = Array.isArray(keys) ? keys : [keys]
+      for (const k of arr) store.delete(k)
+      return Promise.resolve(arr.length)
+    },
+    list: (opts?: { prefix?: string }) => {
+      const prefix = opts?.prefix ?? ''
+      const result = new Map<string, unknown>()
+      for (const [k, v] of store) {
+        if (k.startsWith(prefix)) result.set(k, v)
+      }
+      return Promise.resolve(result)
+    },
+  } as unknown as DurableObjectStorage & { readonly store: Map<string, unknown> }
+}
+
+describe('repairEpoch0Timestamps', () => {
+  it('replaces both epoch-0 timestamps with now', async () => {
+    const storage = createMockStorage()
+    storage.store.set('dsh-kv:workspace:workspaces:ws-1', {
+      path: '/workspace',
+      title: 'workspace',
+      sessionIds: [],
+      createdAt: EPOCH_0,
+      updatedAt: EPOCH_0,
+    })
+    await DurableObjectStorageBackend.repairEpoch0Timestamps(storage)
+    const record = storage.store.get('dsh-kv:workspace:workspaces:ws-1') as Record<string, unknown>
+    expect(record.createdAt).not.toBe(EPOCH_0)
+    expect(record.updatedAt).not.toBe(EPOCH_0)
+    expect(record.createdAt).toBe(record.updatedAt)
+  })
+
+  it('derives createdAt from updatedAt when only createdAt is epoch-0', async () => {
+    const storage = createMockStorage()
+    storage.store.set('dsh-kv:workspace:workspaces:ws-2', {
+      path: '/workspace',
+      title: 'workspace',
+      sessionIds: ['s-1'],
+      createdAt: EPOCH_0,
+      updatedAt: REAL_TS,
+    })
+    await DurableObjectStorageBackend.repairEpoch0Timestamps(storage)
+    const record = storage.store.get('dsh-kv:workspace:workspaces:ws-2') as Record<string, unknown>
+    expect(record.createdAt).toBe(REAL_TS)
+    expect(record.updatedAt).toBe(REAL_TS)
+  })
+
+  it('derives updatedAt from createdAt when only updatedAt is epoch-0', async () => {
+    const storage = createMockStorage()
+    storage.store.set('dsh-kv:workspace:workspaces:ws-3', {
+      path: '/workspace',
+      title: 'workspace',
+      sessionIds: [],
+      createdAt: REAL_TS,
+      updatedAt: EPOCH_0,
+    })
+    await DurableObjectStorageBackend.repairEpoch0Timestamps(storage)
+    const record = storage.store.get('dsh-kv:workspace:workspaces:ws-3') as Record<string, unknown>
+    expect(record.createdAt).toBe(REAL_TS)
+    expect(record.updatedAt).toBe(REAL_TS)
+  })
+
+  it('skips records with valid timestamps', async () => {
+    const storage = createMockStorage()
+    storage.store.set('dsh-kv:workspace:workspaces:ws-ok', {
+      path: '/workspace',
+      title: 'workspace',
+      sessionIds: [],
+      createdAt: REAL_TS,
+      updatedAt: REAL_TS,
+    })
+    await DurableObjectStorageBackend.repairEpoch0Timestamps(storage)
+    const record = storage.store.get('dsh-kv:workspace:workspaces:ws-ok') as Record<string, unknown>
+    expect(record.createdAt).toBe(REAL_TS)
+    expect(record.updatedAt).toBe(REAL_TS)
+  })
+})
+
+describe('migrateWorkspaceKeys', () => {
+  it('repairs epoch-0 timestamps during migration', async () => {
+    const storage = createMockStorage()
+    storage.store.set('dsh-edge:workspace-domain-state:v2', {
+      initialized: true,
+      workspaceIds: ['edge-workspace'],
+    })
+    storage.store.set('dsh-edge:workspace-domain-workspaces:edge-workspace:v2', {
+      path: '/workspace',
+      title: 'Workspace',
+      sessionIds: [],
+      createdAt: EPOCH_0,
+      updatedAt: REAL_TS,
+    })
+    await DurableObjectStorageBackend.migrateWorkspaceKeys(storage)
+    const record = storage.store.get('dsh-kv:workspace:workspaces:edge-workspace') as Record<string, unknown>
+    expect(record.createdAt).toBe(REAL_TS)
+    expect(record.updatedAt).toBe(REAL_TS)
+    expect(storage.store.has('dsh-edge:workspace-domain-state:v2')).toBe(false)
+    expect(storage.store.has('dsh-edge:workspace-domain-workspaces:edge-workspace:v2')).toBe(false)
+  })
+})

--- a/apps/dsh-edge/tests/do-storage-backend.spec.ts
+++ b/apps/dsh-edge/tests/do-storage-backend.spec.ts
@@ -87,6 +87,26 @@ describe('repairEpoch0Timestamps', () => {
     expect(record.createdAt).toBe(REAL_TS)
     expect(record.updatedAt).toBe(REAL_TS)
   })
+
+  it('sets a marker and skips subsequent activations', async () => {
+    const storage = createMockStorage()
+    storage.store.set('dsh-kv:workspace:workspaces:ws-m', {
+      path: '/workspace',
+      title: 'workspace',
+      sessionIds: [],
+      createdAt: EPOCH_0,
+      updatedAt: EPOCH_0,
+    })
+    await DurableObjectStorageBackend.repairEpoch0Timestamps(storage)
+    expect(storage.store.get('dsh-edge:workspace-epoch0-repaired')).toBe(true)
+    const record = storage.store.get('dsh-kv:workspace:workspaces:ws-m') as Record<string, unknown>
+    expect(record.createdAt).not.toBe(EPOCH_0)
+
+    // Second call with marker set — should not scan records
+    record.createdAt = EPOCH_0
+    await DurableObjectStorageBackend.repairEpoch0Timestamps(storage)
+    expect(record.createdAt).toBe(EPOCH_0)
+  })
 })
 
 describe('migrateWorkspaceKeys', () => {

--- a/apps/dsh-edge/tests/fixtures/dsh-edge-0.1.3-workspace.json
+++ b/apps/dsh-edge/tests/fixtures/dsh-edge-0.1.3-workspace.json
@@ -15,7 +15,7 @@
       "session-v0-1-3-blank",
       "session-v0-1-3"
     ],
-    "createdAt": "2026-08-18T00:00:00.000Z",
+    "createdAt": "1970-01-01T00:00:00.000Z",
     "updatedAt": "2026-08-18T00:01:00.000Z"
   }
 }

--- a/apps/dsh-edge/tests/session.integration.mjs
+++ b/apps/dsh-edge/tests/session.integration.mjs
@@ -105,6 +105,12 @@ try {
   assert.deepEqual(releasedWorkspace.body.result.value.archivedSessionIds, [
     RELEASED_ARCHIVED_SESSION_ID,
   ])
+  // Epoch-0 createdAt from fixture must be repaired during migration
+  const migratedWorkspace = releasedWorkspace.body.result.value.items[0]
+  assert.notEqual(migratedWorkspace.createdAt, '1970-01-01T00:00:00.000Z',
+    'epoch-0 createdAt should be repaired')
+  assert.ok(migratedWorkspace.createdAt <= migratedWorkspace.updatedAt,
+    'repaired createdAt must not be later than updatedAt')
   const upgradedReleasedWorkspace = await rpc('workspace.rename', {
     workspaceId: 'edge-workspace',
     title: 'Upgraded 0.1.3 workspace',

--- a/packages/client/ui-edge/src/client/EdgeDirectoryFlow.module.css
+++ b/packages/client/ui-edge/src/client/EdgeDirectoryFlow.module.css
@@ -1,0 +1,106 @@
+.overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 999;
+}
+
+.popover {
+  position: absolute;
+  top: calc(100% + 6px);
+  right: 0;
+  width: 272px;
+  background: var(--dsh-surface-2, #252526);
+  border: 1px solid var(--dsh-border, #3e3e42);
+  border-radius: 8px;
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4), 0 2px 8px rgba(0, 0, 0, 0.3);
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  z-index: 1000;
+}
+
+.title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--dsh-text-1, #ccc);
+}
+
+.inputGroup {
+  display: flex;
+  border-radius: 6px;
+  overflow: hidden;
+  border: 1px solid var(--dsh-border, #3e3e42);
+  transition: border-color 0.15s;
+}
+
+.inputGroup:focus-within {
+  border-color: var(--dsh-accent, #3b82f6);
+}
+
+.inputGroup.error {
+  border-color: var(--dsh-error, #ef4444);
+}
+
+.prefix {
+  background: var(--dsh-surface-1, #1a1a1a);
+  color: var(--dsh-text-3, #6b6b6b);
+  font-size: 12px;
+  padding: 6px 2px 6px 8px;
+  white-space: nowrap;
+  font-family: var(--dsh-font-mono, 'SF Mono', 'Menlo', monospace);
+  user-select: none;
+  border-right: 1px solid var(--dsh-border, #3e3e42);
+  display: flex;
+  align-items: center;
+}
+
+.input {
+  flex: 1;
+  background: var(--dsh-surface-3, #2d2d2d);
+  border: none;
+  color: var(--dsh-text-1, #ccc);
+  font-size: 12px;
+  padding: 6px 8px;
+  font-family: var(--dsh-font-mono, 'SF Mono', 'Menlo', monospace);
+  outline: none;
+  min-width: 0;
+}
+
+.input::placeholder {
+  color: var(--dsh-text-3, #6b6b6b);
+}
+
+.hint {
+  font-size: 11px;
+  color: var(--dsh-text-3, #6b6b6b);
+  line-height: 1.4;
+}
+
+.errorText {
+  font-size: 11px;
+  color: var(--dsh-error, #ef4444);
+  line-height: 1.4;
+}
+
+.submitBtn {
+  background: var(--dsh-accent, #3b82f6);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  padding: 6px 0;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  width: 100%;
+  transition: opacity 0.15s;
+}
+
+.submitBtn:hover {
+  opacity: 0.9;
+}
+
+.submitBtn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}

--- a/packages/client/ui-edge/src/client/EdgeDirectoryFlow.tsx
+++ b/packages/client/ui-edge/src/client/EdgeDirectoryFlow.tsx
@@ -1,0 +1,91 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import css from './EdgeDirectoryFlow.module.css'
+
+interface EdgeDirectoryFlowProps {
+  open: boolean
+  busy: boolean
+  onPicked: (path: string) => void
+  onCancel: () => void
+  onError: (message: string) => void
+}
+
+const WORKSPACE_PREFIX = '/workspace/'
+
+function validate(name: string): string | null {
+  if (name.length === 0) return null
+  if (name.includes('/')) return 'Name cannot contain /'
+  if (name === '.' || name === '..') return 'Invalid directory name'
+  if (name.includes('\0')) return 'Invalid characters'
+  return ''
+}
+
+export function EdgeDirectoryFlow(props: EdgeDirectoryFlowProps): ReactNode {
+  const { open, busy, onPicked, onCancel } = props
+  const [name, setName] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+  const popoverRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (open) {
+      setName('')
+      requestAnimationFrame(() => inputRef.current?.focus())
+    }
+  }, [open])
+
+  const handleClickOutside = useCallback((e: MouseEvent) => {
+    if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+      onCancel()
+    }
+  }, [onCancel])
+
+  useEffect(() => {
+    if (!open) return
+    document.addEventListener('mousedown', handleClickOutside, true)
+    return () => document.removeEventListener('mousedown', handleClickOutside, true)
+  }, [open, handleClickOutside])
+
+  const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') {
+      e.stopPropagation()
+      onCancel()
+    } else if (e.key === 'Enter') {
+      const v = validate(name)
+      if (v === '') onPicked(WORKSPACE_PREFIX + name)
+    }
+  }, [name, onPicked, onCancel])
+
+  if (!open) return null
+
+  const validation = validate(name)
+  const isValid = validation === ''
+  const isError = validation !== null && validation !== ''
+
+  return (
+    <div ref={popoverRef} className={css.popover}>
+      <span className={css.title}>New Workspace</span>
+      <div className={`${css.inputGroup}${isError ? ` ${css.error}` : ''}`}>
+        <span className={css.prefix}>{WORKSPACE_PREFIX}</span>
+        <input
+          ref={inputRef}
+          className={css.input}
+          type="text"
+          placeholder="project-name"
+          value={name}
+          onChange={e => setName(e.target.value)}
+          onKeyDown={handleKeyDown}
+          disabled={busy}
+        />
+      </div>
+      {isError && <span className={css.errorText}>{validation}</span>}
+      {!isError && !isValid && <span className={css.hint}>Enter a project directory name</span>}
+      {isValid && <span className={css.hint}>{WORKSPACE_PREFIX}{name}</span>}
+      <button
+        className={css.submitBtn}
+        disabled={!isValid || busy}
+        onClick={() => onPicked(WORKSPACE_PREFIX + name)}
+      >
+        {busy ? 'Creating…' : 'Create'}
+      </button>
+    </div>
+  )
+}

--- a/packages/client/ui-edge/src/client/EdgeDirectoryFlow.tsx
+++ b/packages/client/ui-edge/src/client/EdgeDirectoryFlow.tsx
@@ -1,26 +1,28 @@
 import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import type { EdgeSettingsKey } from './locales.ts'
 import css from './EdgeDirectoryFlow.module.css'
 
-interface EdgeDirectoryFlowProps {
+export interface EdgeDirectoryFlowProps {
   open: boolean
   busy: boolean
   onPicked: (path: string) => void
   onCancel: () => void
   onError: (message: string) => void
+  t: (key: EdgeSettingsKey) => string
 }
 
 const WORKSPACE_PREFIX = '/workspace/'
 
-function validate(name: string): string | null {
+function validate(name: string, t: (key: EdgeSettingsKey) => string): string | null {
   if (name.length === 0) return null
-  if (name.includes('/')) return 'Name cannot contain /'
-  if (name === '.' || name === '..') return 'Invalid directory name'
-  if (name.includes('\0')) return 'Invalid characters'
+  if (name.includes('/')) return t('workspaceNewErrorSlash')
+  if (name === '.' || name === '..') return t('workspaceNewErrorTraversal')
+  if (name.includes('\0')) return t('workspaceNewErrorChars')
   return ''
 }
 
 export function EdgeDirectoryFlow(props: EdgeDirectoryFlowProps): ReactNode {
-  const { open, busy, onPicked, onCancel } = props
+  const { open, busy, onPicked, onCancel, t } = props
   const [name, setName] = useState('')
   const inputRef = useRef<HTMLInputElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
@@ -32,44 +34,50 @@ export function EdgeDirectoryFlow(props: EdgeDirectoryFlowProps): ReactNode {
     }
   }, [open])
 
-  const handleClickOutside = useCallback((e: MouseEvent) => {
-    if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
-      onCancel()
-    }
-  }, [onCancel])
-
   useEffect(() => {
     if (!open) return
+    const handleClickOutside = (e: MouseEvent) => {
+      if (popoverRef.current && !popoverRef.current.contains(e.target as Node)) {
+        onCancel()
+      }
+    }
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        e.stopPropagation()
+        onCancel()
+      }
+    }
     document.addEventListener('mousedown', handleClickOutside, true)
-    return () => document.removeEventListener('mousedown', handleClickOutside, true)
-  }, [open, handleClickOutside])
+    document.addEventListener('keydown', handleEscape, true)
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside, true)
+      document.removeEventListener('keydown', handleEscape, true)
+    }
+  }, [open, onCancel])
 
   const handleKeyDown = useCallback((e: React.KeyboardEvent) => {
-    if (e.key === 'Escape') {
-      e.stopPropagation()
-      onCancel()
-    } else if (e.key === 'Enter') {
-      const v = validate(name)
+    if (e.key === 'Enter') {
+      const v = validate(name, t)
       if (v === '') onPicked(WORKSPACE_PREFIX + name)
     }
-  }, [name, onPicked, onCancel])
+  }, [name, onPicked, t])
 
   if (!open) return null
 
-  const validation = validate(name)
+  const validation = validate(name, t)
   const isValid = validation === ''
   const isError = validation !== null && validation !== ''
 
   return (
     <div ref={popoverRef} className={css.popover}>
-      <span className={css.title}>New Workspace</span>
+      <span className={css.title}>{t('workspaceNewTitle')}</span>
       <div className={`${css.inputGroup}${isError ? ` ${css.error}` : ''}`}>
         <span className={css.prefix}>{WORKSPACE_PREFIX}</span>
         <input
           ref={inputRef}
           className={css.input}
           type="text"
-          placeholder="project-name"
+          placeholder={t('workspaceNewPlaceholder')}
           value={name}
           onChange={e => setName(e.target.value)}
           onKeyDown={handleKeyDown}
@@ -77,14 +85,14 @@ export function EdgeDirectoryFlow(props: EdgeDirectoryFlowProps): ReactNode {
         />
       </div>
       {isError && <span className={css.errorText}>{validation}</span>}
-      {!isError && !isValid && <span className={css.hint}>Enter a project directory name</span>}
+      {!isError && !isValid && <span className={css.hint}>{t('workspaceNewHint')}</span>}
       {isValid && <span className={css.hint}>{WORKSPACE_PREFIX}{name}</span>}
       <button
         className={css.submitBtn}
         disabled={!isValid || busy}
         onClick={() => onPicked(WORKSPACE_PREFIX + name)}
       >
-        {busy ? 'Creating…' : 'Create'}
+        {busy ? t('workspaceNewCreating') : t('workspaceNewCreate')}
       </button>
     </div>
   )

--- a/packages/client/ui-edge/src/client/index.ts
+++ b/packages/client/ui-edge/src/client/index.ts
@@ -76,11 +76,11 @@ export function apply(ctx: ClientContext): void {
   ctx.slots.inject('conversation.hero.workspace.directoryFlow', () =>
     ctx.slots.inject('sidebar.workspaces.directoryFlow', function* () {
       yield ctx.slots.register(
-        { name: 'conversation.hero.workspace.directoryFlow' },
+        { name: 'conversation.hero.workspace.directoryFlow', locale: 'settings.edge' },
         EdgeDirectoryFlow,
       )
       yield ctx.slots.register(
-        { name: 'sidebar.workspaces.directoryFlow' },
+        { name: 'sidebar.workspaces.directoryFlow', locale: 'settings.edge' },
         EdgeDirectoryFlow,
       )
     }),

--- a/packages/client/ui-edge/src/client/index.ts
+++ b/packages/client/ui-edge/src/client/index.ts
@@ -2,6 +2,7 @@ import type { ClientContext } from '@deepseek-ai/dsh-client-runtime/client'
 import { writeClipboard } from '@deepseek-ai/dsh-client-ui-primitives'
 import type {} from '@deepseek-ai/dsh-client-ui-settings/client'
 import type {} from '@deepseek-ai/dsh-client-locale/client'
+import { EdgeDirectoryFlow } from './EdgeDirectoryFlow.tsx'
 import { EdgeSettingsSection, type EdgeSettingsInjected } from './EdgeSettingsSection.tsx'
 import { EdgeSettingsController } from './store.ts'
 import { en, zh, type EdgeSettingsKey } from './locales.ts'
@@ -12,6 +13,30 @@ export type { EdgeSettingsState, EdgeHealth } from './store.ts'
 
 declare module '@deepseek-ai/dsh-client-ui-slots' {
   interface LocaleNamespaceMap { 'settings.edge': EdgeSettingsKey }
+  interface SlotMap {
+    'sidebar.workspaces.directoryFlow': {
+      kind: 'single'
+      scope: 'root'
+      owner: {
+        open: boolean
+        busy: boolean
+        onPicked: (path: string) => void
+        onCancel: () => void
+        onError: (message: string) => void
+      }
+    }
+    'conversation.hero.workspace.directoryFlow': {
+      kind: 'single'
+      scope: 'root'
+      owner: {
+        open: boolean
+        busy: boolean
+        onPicked: (path: string) => void
+        onCancel: () => void
+        onError: (message: string) => void
+      }
+    }
+  }
 }
 
 export const inject = ['slots', 'locale', 'settingsScope']
@@ -48,4 +73,16 @@ export function apply(ctx: ClientContext): void {
     locale: 'settings.edge',
     inject: injected,
   }, EdgeSettingsSection))
+  ctx.slots.inject('conversation.hero.workspace.directoryFlow', () =>
+    ctx.slots.inject('sidebar.workspaces.directoryFlow', function* () {
+      yield ctx.slots.register(
+        { name: 'conversation.hero.workspace.directoryFlow' },
+        EdgeDirectoryFlow,
+      )
+      yield ctx.slots.register(
+        { name: 'sidebar.workspaces.directoryFlow' },
+        EdgeDirectoryFlow,
+      )
+    }),
+  )
 }

--- a/packages/client/ui-edge/src/client/locales.ts
+++ b/packages/client/ui-edge/src/client/locales.ts
@@ -31,6 +31,14 @@ export const en = {
   signOut: 'Sign out',
   signingOut: 'Signing out…',
   signOutFailed: 'Could not sign out. Try again.',
+  workspaceNewTitle: 'New Workspace',
+  workspaceNewPlaceholder: 'project-name',
+  workspaceNewHint: 'Enter a project directory name',
+  workspaceNewCreate: 'Create',
+  workspaceNewCreating: 'Creating…',
+  workspaceNewErrorSlash: 'Name cannot contain /',
+  workspaceNewErrorTraversal: 'Invalid directory name',
+  workspaceNewErrorChars: 'Invalid characters',
 } as const
 
 /** Locale keys shared by the English source and translated Edge settings copy. */
@@ -69,4 +77,12 @@ export const zh: Record<EdgeSettingsKey, string> = {
   signOut: '退出登录',
   signingOut: '正在退出…',
   signOutFailed: '退出失败，请重试。',
+  workspaceNewTitle: '新建工作空间',
+  workspaceNewPlaceholder: '项目名称',
+  workspaceNewHint: '输入项目目录名称',
+  workspaceNewCreate: '创建',
+  workspaceNewCreating: '创建中…',
+  workspaceNewErrorSlash: '名称不能包含 /',
+  workspaceNewErrorTraversal: '无效的目录名称',
+  workspaceNewErrorChars: '包含无效字符',
 }

--- a/packages/client/ui-edge/tests/apply.client.spec.ts
+++ b/packages/client/ui-edge/tests/apply.client.spec.ts
@@ -52,5 +52,8 @@ describe('ui-edge apply', () => {
     const flowNames = new Set(flowEntries.map(e => e.options.name))
     expect(flowNames).toContain('conversation.hero.workspace.directoryFlow')
     expect(flowNames).toContain('sidebar.workspaces.directoryFlow')
+    for (const flow of flowEntries) {
+      expect(flow.options.locale).toBe('settings.edge')
+    }
   })
 })

--- a/packages/client/ui-edge/tests/apply.client.spec.ts
+++ b/packages/client/ui-edge/tests/apply.client.spec.ts
@@ -1,14 +1,15 @@
 import { describe, expect, it, vi } from 'vitest'
 import { apply, inject } from '../src/client/index.ts'
 import { EdgeSettingsSection } from '../src/client/EdgeSettingsSection.tsx'
+import { EdgeDirectoryFlow } from '../src/client/EdgeDirectoryFlow.tsx'
 
 describe('ui-edge apply', () => {
-  it('registers one localized Edge section through the standard settings slot', () => {
+  it('registers the settings section and directory flow slots', () => {
     expect(inject).toEqual(['slots', 'locale', 'settingsScope'])
-    let entry: {
+    const entries: Array<{
       options: Record<string, unknown> & { inject?: () => unknown }
       component: unknown
-    } | undefined
+    }> = []
     const registerLocale = vi.fn()
     const mirror = { persistence: 'memory', load: vi.fn() }
     const ctx = {
@@ -19,9 +20,14 @@ describe('ui-edge apply', () => {
         bind: () => (key: string) => key === 'nav' ? 'DSH Edge' : key,
       },
       slots: {
-        inject: (_name: string, callback: () => unknown) => callback(),
+        inject: (_name: string, callback: () => unknown) => {
+          const result = callback()
+          if (result && typeof result === 'object' && Symbol.iterator in result) {
+            for (const _ of result as Iterable<unknown>) { /* exhaust generator */ }
+          }
+        },
         register: (options: Record<string, unknown>, component: unknown) => {
-          entry = { options, component }
+          entries.push({ options, component })
           return () => {}
         },
       },
@@ -30,14 +36,21 @@ describe('ui-edge apply', () => {
     expect(mirror.persistence).toBe('host')
     expect(mirror.load).toHaveBeenCalledOnce()
     expect(registerLocale).toHaveBeenCalledOnce()
-    expect(entry).toBeDefined()
-    if (entry === undefined) throw new Error('Edge settings slot was not registered')
-    expect(entry.component).toBe(EdgeSettingsSection)
-    expect(entry.options).toMatchObject({ id: 'dsh-edge', order: 90 })
-    expect((entry.options.label as () => string)()).toBe('DSH Edge')
-    const injected = entry.options.inject?.() as import('../src/client/EdgeSettingsSection.tsx').EdgeSettingsInjected
+
+    const settingsEntry = entries.find(e => e.component === EdgeSettingsSection)
+    expect(settingsEntry).toBeDefined()
+    if (settingsEntry === undefined) throw new Error('Edge settings slot was not registered')
+    expect(settingsEntry.options).toMatchObject({ id: 'dsh-edge', order: 90 })
+    expect((settingsEntry.options.label as () => string)()).toBe('DSH Edge')
+    const injected = settingsEntry.options.inject?.() as import('../src/client/EdgeSettingsSection.tsx').EdgeSettingsInjected
     expect(injected.hooks.edgeSettings.getSnapshot().status).toBe('idle')
     expect(typeof injected.load).toBe('function')
     expect(typeof injected.copyUpgrade).toBe('function')
+
+    const flowEntries = entries.filter(e => e.component === EdgeDirectoryFlow)
+    expect(flowEntries).toHaveLength(2)
+    const flowNames = new Set(flowEntries.map(e => e.options.name))
+    expect(flowNames).toContain('conversation.hero.workspace.directoryFlow')
+    expect(flowNames).toContain('sidebar.workspaces.directoryFlow')
   })
 })

--- a/packages/client/ui-edge/tests/directory-flow.client.spec.tsx
+++ b/packages/client/ui-edge/tests/directory-flow.client.spec.tsx
@@ -2,8 +2,12 @@
 import { cleanup, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { EdgeDirectoryFlow } from '../src/client/EdgeDirectoryFlow.tsx'
+import { en } from '../src/client/locales.ts'
 
 afterEach(cleanup)
+
+const dictionary: Record<string, string> = en
+const t = (key: string) => dictionary[key] ?? key
 
 function renderFlow(overrides: Partial<Parameters<typeof EdgeDirectoryFlow>[0]> = {}) {
   const props = {
@@ -12,6 +16,7 @@ function renderFlow(overrides: Partial<Parameters<typeof EdgeDirectoryFlow>[0]> 
     onPicked: vi.fn(),
     onCancel: vi.fn(),
     onError: vi.fn(),
+    t: t as never,
     ...overrides,
   }
   const result = render(<EdgeDirectoryFlow {...props} />)
@@ -61,10 +66,9 @@ describe('EdgeDirectoryFlow', () => {
     expect(props.onPicked).toHaveBeenCalledWith('/workspace/test-app')
   })
 
-  it('calls onCancel on Escape key', () => {
+  it('calls onCancel on Escape key from any element', () => {
     const { props } = renderFlow()
-    const input = screen.getByPlaceholderText('project-name')
-    fireEvent.keyDown(input, { key: 'Escape' })
+    fireEvent.keyDown(document, { key: 'Escape' })
     expect(props.onCancel).toHaveBeenCalledOnce()
   })
 

--- a/packages/client/ui-edge/tests/directory-flow.client.spec.tsx
+++ b/packages/client/ui-edge/tests/directory-flow.client.spec.tsx
@@ -1,0 +1,101 @@
+// @vitest-environment jsdom
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { EdgeDirectoryFlow } from '../src/client/EdgeDirectoryFlow.tsx'
+
+afterEach(cleanup)
+
+function renderFlow(overrides: Partial<Parameters<typeof EdgeDirectoryFlow>[0]> = {}) {
+  const props = {
+    open: true,
+    busy: false,
+    onPicked: vi.fn(),
+    onCancel: vi.fn(),
+    onError: vi.fn(),
+    ...overrides,
+  }
+  const result = render(<EdgeDirectoryFlow {...props} />)
+  return { ...result, props }
+}
+
+describe('EdgeDirectoryFlow', () => {
+  it('renders nothing when closed', () => {
+    const { container } = renderFlow({ open: false })
+    expect(container.innerHTML).toBe('')
+  })
+
+  it('renders the popover with input when open', () => {
+    renderFlow()
+    expect(screen.getByText('New Workspace')).toBeDefined()
+    expect(screen.getByPlaceholderText('project-name')).toBeDefined()
+    expect(screen.getByText('Create')).toBeDefined()
+  })
+
+  it('disables create button when input is empty', () => {
+    renderFlow()
+    const button = screen.getByText('Create') as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+  })
+
+  it('enables create button with valid input', () => {
+    renderFlow()
+    const input = screen.getByPlaceholderText('project-name')
+    fireEvent.change(input, { target: { value: 'my-project' } })
+    const button = screen.getByText('Create') as HTMLButtonElement
+    expect(button.disabled).toBe(false)
+  })
+
+  it('calls onPicked with full path on submit', () => {
+    const { props } = renderFlow()
+    const input = screen.getByPlaceholderText('project-name')
+    fireEvent.change(input, { target: { value: 'my-project' } })
+    fireEvent.click(screen.getByText('Create'))
+    expect(props.onPicked).toHaveBeenCalledWith('/workspace/my-project')
+  })
+
+  it('calls onPicked on Enter key', () => {
+    const { props } = renderFlow()
+    const input = screen.getByPlaceholderText('project-name')
+    fireEvent.change(input, { target: { value: 'test-app' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(props.onPicked).toHaveBeenCalledWith('/workspace/test-app')
+  })
+
+  it('calls onCancel on Escape key', () => {
+    const { props } = renderFlow()
+    const input = screen.getByPlaceholderText('project-name')
+    fireEvent.keyDown(input, { key: 'Escape' })
+    expect(props.onCancel).toHaveBeenCalledOnce()
+  })
+
+  it('shows error for path traversal', () => {
+    renderFlow()
+    const input = screen.getByPlaceholderText('project-name')
+    fireEvent.change(input, { target: { value: '..' } })
+    expect(screen.getByText('Invalid directory name')).toBeDefined()
+    const button = screen.getByText('Create') as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+  })
+
+  it('shows error for slash in name', () => {
+    renderFlow()
+    const input = screen.getByPlaceholderText('project-name')
+    fireEvent.change(input, { target: { value: 'a/b' } })
+    expect(screen.getByText('Name cannot contain /')).toBeDefined()
+  })
+
+  it('does not submit on Enter with invalid input', () => {
+    const { props } = renderFlow()
+    const input = screen.getByPlaceholderText('project-name')
+    fireEvent.change(input, { target: { value: '..' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+    expect(props.onPicked).not.toHaveBeenCalled()
+  })
+
+  it('disables input and button when busy', () => {
+    renderFlow({ busy: true })
+    const input = screen.getByPlaceholderText('project-name') as HTMLInputElement
+    expect(input.disabled).toBe(true)
+    expect(screen.getByText('Creating…')).toBeDefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Repair epoch-0 `createdAt`/`updatedAt` in workspace records left by the old `EdgeWorkspaceStore.defaultWorkspaceRecord()` which used `new Date(0)` when no sessions existed
- Add `EdgeDirectoryFlow` component that replaces the upstream native directory picker (unavailable in Edge context) with a path input popover anchored to the sidebar "+" button

## Details

**createdAt fix**: `repairEpoch0Timestamps()` runs on every DO boot, scanning `dsh-kv:workspace:workspaces:*` records for the epoch-0 ISO string and replacing with current time. Also fixes future migrations in `migrateWorkspaceKeys()`.

**Directory picker**: Registers into both `sidebar.workspaces.directoryFlow` and `conversation.hero.workspace.directoryFlow` slots via the Edge client plugin. Shows a popover with fixed `/workspace/` prefix, validates input (rejects `/`, `..`, empty), calls `onPicked(path)` on submit. This makes the sidebar "+" button functional — it was previously invisible because no directory flow occupant was registered.

## Test plan

- [ ] CI passes
- [ ] Deploy and verify "Workspace 12" no longer shows epoch-0 date
- [ ] Click "+" in sidebar — popover appears with path input
- [ ] Enter valid name → workspace created
- [ ] Enter `../foo` → validation error shown
- [ ] Press Escape or click outside → popover dismisses

🤖 Generated with [Claude Code](https://claude.com/claude-code)