### PR TITLE
release: dsh-edge 0.6.0-alpha.3

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.6.0-alpha.2",
+  "version": "0.6.0-alpha.3",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.6.0-alpha.3.i18n.yaml
+++ b/docs/releases/0.6.0-alpha.3.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.6.0-alpha.3.md: 7483c17357b3dd032bf1d494929703960f5105d2
+0.6.0-alpha.3.zh.md: 999e40d71ac0c69d32c43fb8db6ae53c73b4ed6d

--- a/docs/releases/0.6.0-alpha.3.md
+++ b/docs/releases/0.6.0-alpha.3.md
@@ -1,0 +1,19 @@
+## dsh-edge 0.6.0-alpha.3
+
+Fixes workspace timestamp display and adds the Edge directory picker for multi-workspace creation.
+
+### Fixed
+
+- **Epoch-0 workspace timestamps**: legacy `EdgeWorkspaceStore` wrote `new Date(0)` as `createdAt` for workspaces with no sessions. Migration and a one-time boot repair now derive `createdAt` from `updatedAt` (or vice versa) to preserve chronological ordering.
+- **Escape key scope**: the workspace picker popover now dismisses on Escape from any focused element, not just the input.
+
+### Added
+
+- **Edge directory picker**: registers into the upstream `directoryFlow` slot to replace the native OS directory picker (unavailable in the Edge browser context). Shows a popover with fixed `/workspace/` prefix, input validation, and localized strings (en/zh).
+- **Repair migration marker**: `repairEpoch0Timestamps` writes a durable marker after the first scan so subsequent DO activations skip the O(n) workspace record list.
+
+### Technical
+
+- `EdgeDirectoryFlow` component occupies both `sidebar.workspaces.directoryFlow` and `conversation.hero.workspace.directoryFlow` slots.
+- `repairEpoch0()` helper shared by migration and boot-time repair paths.
+- 6 new unit tests (epoch-0 repair), 10 component tests (directory flow), 1 integration assertion (epoch-0 fixture).

--- a/docs/releases/0.6.0-alpha.3.zh.md
+++ b/docs/releases/0.6.0-alpha.3.zh.md
@@ -1,0 +1,19 @@
+## dsh-edge 0.6.0-alpha.3
+
+修复工作空间时间戳显示问题，新增 Edge 目录选择器支持多工作空间创建。
+
+### 修复
+
+- **Epoch-0 工作空间时间戳**：旧版 `EdgeWorkspaceStore` 在没有 session 时将 `createdAt` 写为 `new Date(0)`。迁移和一次性启动修复现在从 `updatedAt` 推导 `createdAt`（或反之），保持时间顺序一致。
+- **Escape 键作用域**：工作空间选择器弹窗现在在任意焦点元素上按 Escape 都能关闭，不仅限于输入框。
+
+### 新增
+
+- **Edge 目录选择器**：注册到上游 `directoryFlow` slot，替代不可用的原生 OS 目录选择器。显示带固定 `/workspace/` 前缀的弹窗，支持输入校验和本地化字符串（中/英文）。
+- **修复迁移标记**：`repairEpoch0Timestamps` 在首次扫描后写入持久化标记，后续 DO 激活跳过 O(n) 的工作空间记录扫描。
+
+### 技术细节
+
+- `EdgeDirectoryFlow` 组件同时占据 `sidebar.workspaces.directoryFlow` 和 `conversation.hero.workspace.directoryFlow` 两个 slot。
+- `repairEpoch0()` 辅助函数由迁移路径和启动修复路径共享。
+- 新增 6 个单元测试（epoch-0 修复）、10 个组件测试（目录选择器）、1 个集成断言（epoch-0 fixture）。


### PR DESCRIPTION
## Summary

- Bump to 0.6.0-alpha.3
- Bilingual release notes for epoch-0 timestamp fix and Edge directory picker

## Test plan

- [ ] CI passes
- [ ] Merge, tag, push tag
- [ ] `npm view dsh-edge@0.6.0-alpha.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)