### PR TITLE
fix: anchor directory picker popover to + button

### DIFF
--- a/packages/client/ui-edge/src/client/EdgeDirectoryFlow.module.css
+++ b/packages/client/ui-edge/src/client/EdgeDirectoryFlow.module.css
@@ -5,10 +5,7 @@
 }
 
 .popover {
-  position: absolute;
-  top: calc(100% + 6px);
-  right: 0;
-  width: 272px;
+  position: fixed;
   background: var(--dsh-surface-2, #252526);
   border: 1px solid var(--dsh-border, #3e3e42);
   border-radius: 8px;

--- a/packages/client/ui-edge/src/client/EdgeDirectoryFlow.tsx
+++ b/packages/client/ui-edge/src/client/EdgeDirectoryFlow.tsx
@@ -12,6 +12,8 @@ export interface EdgeDirectoryFlowProps {
 }
 
 const WORKSPACE_PREFIX = '/workspace/'
+const POPOVER_WIDTH = 260
+const VIEWPORT_MARGIN = 8
 
 function validate(name: string, t: (key: EdgeSettingsKey) => string): string | null {
   if (name.length === 0) return null
@@ -21,14 +23,21 @@ function validate(name: string, t: (key: EdgeSettingsKey) => string): string | n
   return ''
 }
 
-function findAnchorRect(slotEl: HTMLElement | null): DOMRect | null {
+function findAnchorButton(slotEl: HTMLElement | null): HTMLElement | null {
   let node = slotEl?.parentElement ?? null
   while (node !== null) {
     const btn = node.querySelector<HTMLElement>('button[aria-label]')
-    if (btn !== null) return btn.getBoundingClientRect()
+    if (btn !== null) return btn
     node = node.parentElement
   }
   return null
+}
+
+function computeAnchor(btn: HTMLElement | null): { top: number; left: number } {
+  if (btn === null) return { top: 60, left: 12 }
+  const rect = btn.getBoundingClientRect()
+  const left = Math.min(rect.left, window.innerWidth - POPOVER_WIDTH - VIEWPORT_MARGIN)
+  return { top: rect.bottom + 6, left: Math.max(VIEWPORT_MARGIN, left) }
 }
 
 export function EdgeDirectoryFlow(props: EdgeDirectoryFlowProps): ReactNode {
@@ -38,18 +47,26 @@ export function EdgeDirectoryFlow(props: EdgeDirectoryFlowProps): ReactNode {
   const inputRef = useRef<HTMLInputElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
   const slotRef = useRef<HTMLSpanElement>(null)
+  const btnRef = useRef<HTMLElement | null>(null)
 
   useEffect(() => {
     if (!open) {
       setAnchor(null)
+      btnRef.current = null
       return
     }
     setName('')
-    const rect = findAnchorRect(slotRef.current)
-    setAnchor(rect !== null
-      ? { top: rect.bottom + 6, left: rect.left }
-      : { top: 60, left: 12 })
+    btnRef.current = findAnchorButton(slotRef.current)
+    setAnchor(computeAnchor(btnRef.current))
     requestAnimationFrame(() => inputRef.current?.focus())
+
+    const recompute = () => setAnchor(computeAnchor(btnRef.current))
+    window.addEventListener('resize', recompute)
+    window.addEventListener('scroll', recompute, true)
+    return () => {
+      window.removeEventListener('resize', recompute)
+      window.removeEventListener('scroll', recompute, true)
+    }
   }, [open])
 
   useEffect(() => {
@@ -92,7 +109,7 @@ export function EdgeDirectoryFlow(props: EdgeDirectoryFlowProps): ReactNode {
       <div
         ref={popoverRef}
         className={css.popover}
-        style={{ top: anchor.top, left: anchor.left }}
+        style={{ top: anchor.top, left: anchor.left, width: POPOVER_WIDTH }}
       >
         <span className={css.title}>{t('workspaceNewTitle')}</span>
         <div className={`${css.inputGroup}${isError ? ` ${css.error}` : ''}`}>

--- a/packages/client/ui-edge/src/client/EdgeDirectoryFlow.tsx
+++ b/packages/client/ui-edge/src/client/EdgeDirectoryFlow.tsx
@@ -13,6 +13,7 @@ export interface EdgeDirectoryFlowProps {
 
 const WORKSPACE_PREFIX = '/workspace/'
 const POPOVER_WIDTH = 260
+const POPOVER_HEIGHT_ESTIMATE = 160
 const VIEWPORT_MARGIN = 8
 
 function validate(name: string, t: (key: EdgeSettingsKey) => string): string | null {
@@ -37,7 +38,11 @@ function computeAnchor(btn: HTMLElement | null): { top: number; left: number } {
   if (btn === null) return { top: 60, left: 12 }
   const rect = btn.getBoundingClientRect()
   const left = Math.min(rect.left, window.innerWidth - POPOVER_WIDTH - VIEWPORT_MARGIN)
-  return { top: rect.bottom + 6, left: Math.max(VIEWPORT_MARGIN, left) }
+  const belowTop = rect.bottom + 6
+  const aboveTop = rect.top - POPOVER_HEIGHT_ESTIMATE - 6
+  const fitsBelow = belowTop + POPOVER_HEIGHT_ESTIMATE + VIEWPORT_MARGIN <= window.innerHeight
+  const top = fitsBelow ? belowTop : Math.max(VIEWPORT_MARGIN, aboveTop)
+  return { top, left: Math.max(VIEWPORT_MARGIN, left) }
 }
 
 export function EdgeDirectoryFlow(props: EdgeDirectoryFlowProps): ReactNode {

--- a/packages/client/ui-edge/src/client/EdgeDirectoryFlow.tsx
+++ b/packages/client/ui-edge/src/client/EdgeDirectoryFlow.tsx
@@ -21,17 +21,35 @@ function validate(name: string, t: (key: EdgeSettingsKey) => string): string | n
   return ''
 }
 
+function findAnchorRect(slotEl: HTMLElement | null): DOMRect | null {
+  let node = slotEl?.parentElement ?? null
+  while (node !== null) {
+    const btn = node.querySelector<HTMLElement>('button[aria-label]')
+    if (btn !== null) return btn.getBoundingClientRect()
+    node = node.parentElement
+  }
+  return null
+}
+
 export function EdgeDirectoryFlow(props: EdgeDirectoryFlowProps): ReactNode {
   const { open, busy, onPicked, onCancel, t } = props
   const [name, setName] = useState('')
+  const [anchor, setAnchor] = useState<{ top: number; left: number } | null>(null)
   const inputRef = useRef<HTMLInputElement>(null)
   const popoverRef = useRef<HTMLDivElement>(null)
+  const slotRef = useRef<HTMLSpanElement>(null)
 
   useEffect(() => {
-    if (open) {
-      setName('')
-      requestAnimationFrame(() => inputRef.current?.focus())
+    if (!open) {
+      setAnchor(null)
+      return
     }
+    setName('')
+    const rect = findAnchorRect(slotRef.current)
+    setAnchor(rect !== null
+      ? { top: rect.bottom + 6, left: rect.left }
+      : { top: 60, left: 12 })
+    requestAnimationFrame(() => inputRef.current?.focus())
   }, [open])
 
   useEffect(() => {
@@ -62,38 +80,45 @@ export function EdgeDirectoryFlow(props: EdgeDirectoryFlowProps): ReactNode {
     }
   }, [name, onPicked, t])
 
-  if (!open) return null
+  if (!open || anchor === null) return <span ref={slotRef} />
 
   const validation = validate(name, t)
   const isValid = validation === ''
   const isError = validation !== null && validation !== ''
 
   return (
-    <div ref={popoverRef} className={css.popover}>
-      <span className={css.title}>{t('workspaceNewTitle')}</span>
-      <div className={`${css.inputGroup}${isError ? ` ${css.error}` : ''}`}>
-        <span className={css.prefix}>{WORKSPACE_PREFIX}</span>
-        <input
-          ref={inputRef}
-          className={css.input}
-          type="text"
-          placeholder={t('workspaceNewPlaceholder')}
-          value={name}
-          onChange={e => setName(e.target.value)}
-          onKeyDown={handleKeyDown}
-          disabled={busy}
-        />
-      </div>
-      {isError && <span className={css.errorText}>{validation}</span>}
-      {!isError && !isValid && <span className={css.hint}>{t('workspaceNewHint')}</span>}
-      {isValid && <span className={css.hint}>{WORKSPACE_PREFIX}{name}</span>}
-      <button
-        className={css.submitBtn}
-        disabled={!isValid || busy}
-        onClick={() => onPicked(WORKSPACE_PREFIX + name)}
+    <>
+      <span ref={slotRef} />
+      <div
+        ref={popoverRef}
+        className={css.popover}
+        style={{ top: anchor.top, left: anchor.left }}
       >
-        {busy ? t('workspaceNewCreating') : t('workspaceNewCreate')}
-      </button>
-    </div>
+        <span className={css.title}>{t('workspaceNewTitle')}</span>
+        <div className={`${css.inputGroup}${isError ? ` ${css.error}` : ''}`}>
+          <span className={css.prefix}>{WORKSPACE_PREFIX}</span>
+          <input
+            ref={inputRef}
+            className={css.input}
+            type="text"
+            placeholder={t('workspaceNewPlaceholder')}
+            value={name}
+            onChange={e => setName(e.target.value)}
+            onKeyDown={handleKeyDown}
+            disabled={busy}
+          />
+        </div>
+        {isError && <span className={css.errorText}>{validation}</span>}
+        {!isError && !isValid && <span className={css.hint}>{t('workspaceNewHint')}</span>}
+        {isValid && <span className={css.hint}>{WORKSPACE_PREFIX}{name}</span>}
+        <button
+          className={css.submitBtn}
+          disabled={!isValid || busy}
+          onClick={() => onPicked(WORKSPACE_PREFIX + name)}
+        >
+          {busy ? t('workspaceNewCreating') : t('workspaceNewCreate')}
+        </button>
+      </div>
+    </>
   )
 }

--- a/packages/client/ui-edge/src/client/EdgeDirectoryFlow.tsx
+++ b/packages/client/ui-edge/src/client/EdgeDirectoryFlow.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react'
+import { useCallback, useEffect, useLayoutEffect, useRef, useState, type ReactNode } from 'react'
 import type { EdgeSettingsKey } from './locales.ts'
 import css from './EdgeDirectoryFlow.module.css'
 
@@ -13,7 +13,6 @@ export interface EdgeDirectoryFlowProps {
 
 const WORKSPACE_PREFIX = '/workspace/'
 const POPOVER_WIDTH = 260
-const POPOVER_HEIGHT_ESTIMATE = 160
 const VIEWPORT_MARGIN = 8
 
 function validate(name: string, t: (key: EdgeSettingsKey) => string): string | null {
@@ -34,13 +33,17 @@ function findAnchorButton(slotEl: HTMLElement | null): HTMLElement | null {
   return null
 }
 
-function computeAnchor(btn: HTMLElement | null): { top: number; left: number } {
+function computeAnchor(
+  btn: HTMLElement | null,
+  popover: HTMLElement | null,
+): { top: number; left: number } {
   if (btn === null) return { top: 60, left: 12 }
   const rect = btn.getBoundingClientRect()
   const left = Math.min(rect.left, window.innerWidth - POPOVER_WIDTH - VIEWPORT_MARGIN)
+  const panelHeight = popover?.offsetHeight ?? 160
   const belowTop = rect.bottom + 6
-  const aboveTop = rect.top - POPOVER_HEIGHT_ESTIMATE - 6
-  const fitsBelow = belowTop + POPOVER_HEIGHT_ESTIMATE + VIEWPORT_MARGIN <= window.innerHeight
+  const aboveTop = rect.top - panelHeight - 6
+  const fitsBelow = belowTop + panelHeight + VIEWPORT_MARGIN <= window.innerHeight
   const top = fitsBelow ? belowTop : Math.max(VIEWPORT_MARGIN, aboveTop)
   return { top, left: Math.max(VIEWPORT_MARGIN, left) }
 }
@@ -62,10 +65,10 @@ export function EdgeDirectoryFlow(props: EdgeDirectoryFlowProps): ReactNode {
     }
     setName('')
     btnRef.current = findAnchorButton(slotRef.current)
-    setAnchor(computeAnchor(btnRef.current))
+    setAnchor(computeAnchor(btnRef.current, popoverRef.current))
     requestAnimationFrame(() => inputRef.current?.focus())
 
-    const recompute = () => setAnchor(computeAnchor(btnRef.current))
+    const recompute = () => setAnchor(computeAnchor(btnRef.current, popoverRef.current))
     window.addEventListener('resize', recompute)
     window.addEventListener('scroll', recompute, true)
     return () => {
@@ -73,6 +76,13 @@ export function EdgeDirectoryFlow(props: EdgeDirectoryFlowProps): ReactNode {
       window.removeEventListener('scroll', recompute, true)
     }
   }, [open])
+
+  useLayoutEffect(() => {
+    if (!open || popoverRef.current === null) return
+    const next = computeAnchor(btnRef.current, popoverRef.current)
+    setAnchor(prev =>
+      prev !== null && prev.top === next.top && prev.left === next.left ? prev : next)
+  })
 
   useEffect(() => {
     if (!open) return

--- a/packages/client/ui-edge/tests/directory-flow.client.spec.tsx
+++ b/packages/client/ui-edge/tests/directory-flow.client.spec.tsx
@@ -24,9 +24,9 @@ function renderFlow(overrides: Partial<Parameters<typeof EdgeDirectoryFlow>[0]> 
 }
 
 describe('EdgeDirectoryFlow', () => {
-  it('renders nothing when closed', () => {
-    const { container } = renderFlow({ open: false })
-    expect(container.innerHTML).toBe('')
+  it('renders nothing visible when closed', () => {
+    renderFlow({ open: false })
+    expect(screen.queryByText('New Workspace')).toBeNull()
   })
 
   it('renders the popover with input when open', () => {


### PR DESCRIPTION
## Summary

- Fix popover positioning: use `position: fixed` with `getBoundingClientRect()` from the nearest `button[aria-label]` ancestor so the popover anchors to the "+" button instead of rendering at the slot's DOM position (page bottom)
- Render a `<span ref>` marker in the slot to discover the anchor button, popover renders as a sibling with fixed positioning

## Root cause

The upstream `directoryFlow` slot renders below the workspace list in the DOM tree, not next to the "+" button. The native picker avoids this by `return null` (it opens an OS dialog). Our component rendered with `position: absolute` which positioned relative to the slot container.

## Test plan

- [ ] CI passes
- [ ] Deploy and verify popover appears below the "+" button, not at page bottom
- [ ] Existing directory flow tests still pass (24/24)

🤖 Generated with [Claude Code](https://claude.com/claude-code)