### PR TITLE
release: dsh-edge 0.6.0-alpha.4

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.6.0-alpha.3",
+  "version": "0.6.0-alpha.4",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.6.0-alpha.4.i18n.yaml
+++ b/docs/releases/0.6.0-alpha.4.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.6.0-alpha.4.md: faa29358e8f67b26a7528bba86f857d0e5350df6
+0.6.0-alpha.4.zh.md: 7fcd1283ddb85d6a4f0dd1f245cff53a14cfd890

--- a/docs/releases/0.6.0-alpha.4.md
+++ b/docs/releases/0.6.0-alpha.4.md
@@ -1,0 +1,10 @@
+## dsh-edge 0.6.0-alpha.4
+
+Fixes directory picker popover positioning.
+
+### Fixed
+
+- **Popover anchoring**: the workspace directory picker now uses `position: fixed` with coordinates derived from the "+" button's `getBoundingClientRect()`, anchoring correctly regardless of slot DOM position.
+- **Viewport collision**: horizontal clamping prevents overflow on narrow viewports; vertical flip places the popover above the trigger when it would extend below the viewport bottom.
+- **Resize/scroll tracking**: `resize` and `scroll` (capture) listeners recompute anchor coordinates while the popover is open.
+- **Measured height**: `useLayoutEffect` measures actual popover `offsetHeight` for the vertical flip decision instead of a fixed estimate, so content changes (validation messages) update positioning in real time.

--- a/docs/releases/0.6.0-alpha.4.zh.md
+++ b/docs/releases/0.6.0-alpha.4.zh.md
@@ -1,0 +1,10 @@
+## dsh-edge 0.6.0-alpha.4
+
+修复目录选择器弹窗定位问题。
+
+### 修复
+
+- **弹窗锚定**：workspace 目录选择器现在使用 `position: fixed`，通过 "+" 按钮的 `getBoundingClientRect()` 计算坐标，不再受 slot DOM 位置影响。
+- **视口碰撞检测**：水平方向 clamp 防止窄视口溢出；垂直方向当弹窗会超出视口底部时自动翻转到按钮上方显示。
+- **Resize/scroll 跟踪**：弹窗打开期间监听 `resize` 和 `scroll`（capture），实时重算锚定坐标。
+- **实测高度**：`useLayoutEffect` 测量弹窗实际 `offsetHeight` 用于翻转判断，替代固定估值，内容变化（校验消息）时实时更新定位。


### PR DESCRIPTION
## Summary

- Bump to 0.6.0-alpha.4
- Bilingual release notes for directory picker popover positioning fix

## Test plan

- [ ] CI passes
- [ ] Merge, tag `dsh-edge-v0.6.0-alpha.4`, push tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)