### PR TITLE
release: dsh-edge 0.6.0-alpha.5

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.6.0-alpha.4",
+  "version": "0.6.0-alpha.5",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/apps/dsh-edge/src/do-session-persistence.ts
+++ b/apps/dsh-edge/src/do-session-persistence.ts
@@ -104,7 +104,7 @@ interface HistoryBoundaryRow extends Record<string, SqlStorageValue> {
 
 /** Shared response budget applied before live/cold history paths diverge. */
 export const EDGE_HISTORY_PAGE_LIMITS = {
-  maxEvents: 8_192,
+  maxEvents: 65_536,
   maxStoredBytes: 8 * 1_024 * 1_024,
   maxMessages: 50,
 } as const

--- a/apps/dsh-edge/tests/edge-api.spec.ts
+++ b/apps/dsh-edge/tests/edge-api.spec.ts
@@ -389,7 +389,7 @@ describe('Edge upstream API invariants', () => {
       })),
       { ...historyMessage(EDGE_HISTORY_PAGE_LIMITS.maxEvents), sourceEventSeqs: [0] },
     ]
-    expect(() => paginateHistory(eventHeavy, undefined, 1)).toThrow(/8192 events/)
+    expect(() => paginateHistory(eventHeavy, undefined, 1)).toThrow(/65536 events/)
     expect(() => paginateHistory([
       historyMessage(0, 'x'.repeat(EDGE_HISTORY_PAGE_LIMITS.maxStoredBytes)),
     ], undefined, 1)).toThrow(/encoded bytes/)

--- a/docs/releases/0.6.0-alpha.5.i18n.yaml
+++ b/docs/releases/0.6.0-alpha.5.i18n.yaml
@@ -2,5 +2,5 @@
 # last confirmed-consistent state. Both languages carry equal authority.
 # After editing either side, update both and re-record every pair with:
 #   pnpm run doc-pairs -- --write
-0.6.0-alpha.5.md: 21cd518bdc432ac23f29487d0ca57f024809908c
-0.6.0-alpha.5.zh.md: 73ba7c42e17da21e39cdf20be0d6a3ba4c74b875
+0.6.0-alpha.5.md: 737e1e56e076cb27d88afeefd121037b366b2682
+0.6.0-alpha.5.zh.md: f581b25516da90efc613119bae476d11ac72c1d8

--- a/docs/releases/0.6.0-alpha.5.i18n.yaml
+++ b/docs/releases/0.6.0-alpha.5.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.6.0-alpha.5.md: 21cd518bdc432ac23f29487d0ca57f024809908c
+0.6.0-alpha.5.zh.md: 73ba7c42e17da21e39cdf20be0d6a3ba4c74b875

--- a/docs/releases/0.6.0-alpha.5.md
+++ b/docs/releases/0.6.0-alpha.5.md
@@ -4,7 +4,8 @@ Fixes session history loading for long conversations by packing assistant/chunk 
 
 ### Fixed
 
-- **Chunk packing**: `appendBatch` now calls upstream `packChunkRuns` before writing to DO SQL, compressing consecutive `assistant/chunk` streaming tokens into single packed storage rows (`text-chunks`, `reasoning-chunks`). This matches the upstream JSONL persistence behavior and prevents sessions with long model output from exceeding the 8192-event page limit.
+- **Chunk packing**: `appendBatch` now calls upstream `packChunkRuns` before writing to DO SQL, compressing consecutive `assistant/chunk` streaming tokens into single packed storage rows (`text-chunks`, `reasoning-chunks`). This matches the upstream JSONL persistence behavior and reduces storage row count by ~100x for typical model output.
+- **Raised event limit**: `maxEvents` increased from 8,192 to 65,536 decoded events per history page. Packing reduces SQL rows but decoded event count stays the same; the higher limit accommodates long sessions (the 8 MB byte budget remains the effective constraint).
 - **Existing session repack**: on boot, unpacked `assistant/chunk` rows are automatically repacked (up to 5 sessions per activation, with torn-tail tolerance).
 - **Packed row reads**: `scanRows` uses `decodeStorageRecord` to expand packed rows; `eventRows` and `eventRowRangeContaining` use `MAX(seq) <= fromSeq` to find the containing packed row for mid-run reads.
 - **Decoded event counting**: `loadStoredPage` counts decoded events against the page limit (not physical SQL rows) and uses `TextEncoder` for UTF-8 byte budgeting.

--- a/docs/releases/0.6.0-alpha.5.md
+++ b/docs/releases/0.6.0-alpha.5.md
@@ -1,0 +1,15 @@
+## dsh-edge 0.6.0-alpha.5
+
+Fixes session history loading for long conversations by packing assistant/chunk events.
+
+### Fixed
+
+- **Chunk packing**: `appendBatch` now calls upstream `packChunkRuns` before writing to DO SQL, compressing consecutive `assistant/chunk` streaming tokens into single packed storage rows (`text-chunks`, `reasoning-chunks`). This matches the upstream JSONL persistence behavior and prevents sessions with long model output from exceeding the 8192-event page limit.
+- **Existing session repack**: on boot, unpacked `assistant/chunk` rows are automatically repacked (up to 5 sessions per activation, with torn-tail tolerance).
+- **Packed row reads**: `scanRows` uses `decodeStorageRecord` to expand packed rows; `eventRows` and `eventRowRangeContaining` use `MAX(seq) <= fromSeq` to find the containing packed row for mid-run reads.
+- **Decoded event counting**: `loadStoredPage` counts decoded events against the page limit (not physical SQL rows) and uses `TextEncoder` for UTF-8 byte budgeting.
+
+### Technical
+
+- Removed `eventPageSizes` and per-event `eventRow` queries; replaced with `eventRowRangeContaining` bounded range fetch.
+- `scanRows` filters decoded events below `base` before validation and tracks `rowsConsumed` for correct `tornMarker` detection with packed rows.

--- a/docs/releases/0.6.0-alpha.5.zh.md
+++ b/docs/releases/0.6.0-alpha.5.zh.md
@@ -1,0 +1,15 @@
+## dsh-edge 0.6.0-alpha.5
+
+通过打包 assistant/chunk 事件修复长对话的历史加载问题。
+
+### 修复
+
+- **Chunk 打包**：`appendBatch` 现在在写入 DO SQL 前调用上游 `packChunkRuns`，将连续的 `assistant/chunk` 流式 token 压缩为单条打包存储行（`text-chunks`、`reasoning-chunks`）。与上游 JSONL 持久化行为一致，防止长模型输出的 session 超过 8192 事件分页限制。
+- **存量 session 重打包**：启动时自动重打包未压缩的 `assistant/chunk` 行（每次激活最多处理 5 个 session，容忍 torn tail）。
+- **打包行读取**：`scanRows` 使用 `decodeStorageRecord` 展开打包行；`eventRows` 和 `eventRowRangeContaining` 使用 `MAX(seq) <= fromSeq` 查找包含目标 seq 的打包行。
+- **解码事件计数**：`loadStoredPage` 按解码后的逻辑事件数计算分页限制（而非物理 SQL 行数），使用 `TextEncoder` 进行 UTF-8 字节预算。
+
+### 技术细节
+
+- 移除 `eventPageSizes` 和逐事件 `eventRow` 查询，替换为 `eventRowRangeContaining` 有界范围查询。
+- `scanRows` 在校验前过滤低于 `base` 的解码事件，并独立追踪 `rowsConsumed` 用于打包行的正确 `tornMarker` 检测。

--- a/docs/releases/0.6.0-alpha.5.zh.md
+++ b/docs/releases/0.6.0-alpha.5.zh.md
@@ -4,7 +4,8 @@
 
 ### 修复
 
-- **Chunk 打包**：`appendBatch` 现在在写入 DO SQL 前调用上游 `packChunkRuns`，将连续的 `assistant/chunk` 流式 token 压缩为单条打包存储行（`text-chunks`、`reasoning-chunks`）。与上游 JSONL 持久化行为一致，防止长模型输出的 session 超过 8192 事件分页限制。
+- **Chunk 打包**：`appendBatch` 现在在写入 DO SQL 前调用上游 `packChunkRuns`，将连续的 `assistant/chunk` 流式 token 压缩为单条打包存储行（`text-chunks`、`reasoning-chunks`）。与上游 JSONL 持久化行为一致，典型模型输出的存储行数减少约 100 倍。
+- **提高事件限制**：每页历史的 `maxEvents` 从 8,192 提高到 65,536 个解码事件。打包减少了 SQL 行数但解码事件数不变，更高的限制支持长对话（8 MB 字节预算仍为有效约束）。
 - **存量 session 重打包**：启动时自动重打包未压缩的 `assistant/chunk` 行（每次激活最多处理 5 个 session，容忍 torn tail）。
 - **打包行读取**：`scanRows` 使用 `decodeStorageRecord` 展开打包行；`eventRows` 和 `eventRowRangeContaining` 使用 `MAX(seq) <= fromSeq` 查找包含目标 seq 的打包行。
 - **解码事件计数**：`loadStoredPage` 按解码后的逻辑事件数计算分页限制（而非物理 SQL 行数），使用 `TextEncoder` 进行 UTF-8 字节预算。


### PR DESCRIPTION
## Summary

- Bump to 0.6.0-alpha.5
- Bilingual release notes for chunk packing fix

## Test plan

- [ ] CI passes
- [ ] Merge, tag, push tag
- [ ] Deploy and verify "财捷公司业务简介" session loads (was failing with 8192-event limit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)