### PR TITLE
release: dsh-edge 0.6.0-alpha.6

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.6.0-alpha.5",
+  "version": "0.6.0-alpha.6",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.6.0-alpha.6.i18n.yaml
+++ b/docs/releases/0.6.0-alpha.6.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.6.0-alpha.6.md: 1bdd2c20392690e7905c7586689810f0190c87e7
+0.6.0-alpha.6.zh.md: c37edd5967a0342613d0ce8d97f5098070a560c6

--- a/docs/releases/0.6.0-alpha.6.md
+++ b/docs/releases/0.6.0-alpha.6.md
@@ -1,0 +1,7 @@
+## dsh-edge 0.6.0-alpha.6
+
+Debug release to diagnose why boot-time chunk repack is not executing on production DOs.
+
+### Changed
+
+- **Repack error logging**: replaced silent `catch` with `console.error` so repack failures appear in Worker logs instead of being silently swallowed.

--- a/docs/releases/0.6.0-alpha.6.zh.md
+++ b/docs/releases/0.6.0-alpha.6.zh.md
@@ -1,0 +1,7 @@
+## dsh-edge 0.6.0-alpha.6
+
+诊断生产环境 DO 启动时 chunk repack 未执行的问题。
+
+### 变更
+
+- **Repack 错误日志**：将静默 `catch` 替换为 `console.error`，使 repack 失败信息出现在 Worker 日志中。


### PR DESCRIPTION
## Summary

- Bump to 0.6.0-alpha.6
- Debug: log repack errors to diagnose why boot-time chunk repack isn't executing

## Test plan

- [ ] CI passes
- [ ] Merge, tag, deploy
- [ ] Trigger DO cold start, check Worker logs for repack errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)