### PR TITLE
fix: handle packed record seq0/time0 keys and isolate repack with SAVEPOINT

### DIFF
--- a/apps/dsh-edge/src/do-session-persistence.ts
+++ b/apps/dsh-edge/src/do-session-persistence.ts
@@ -456,7 +456,7 @@ export class DurableObjectSessionPersistence
       this.storage.transactionSync(() => {
         if (!isMaterialized) this.writeRow(meta)
         const packed = packChunkRuns(events as SessionEvent[])
-        for (const record of packed) this.insertEvent(meta.id, record as SessionEvent)
+        for (const record of packed) this.insertStorageRecord(meta.id, record)
         const updated = this.storage.sql.exec(
           'UPDATE dsh_sessions SET revision = revision + 1 WHERE id = ?',
           meta.id,
@@ -689,7 +689,7 @@ export class DurableObjectSessionPersistence
 
   private initialize(): string {
     this.storage.sql.exec('PRAGMA foreign_keys = ON')
-    return this.storage.transactionSync(() => {
+    const identity = this.storage.transactionSync(() => {
       this.storage.sql.exec(`CREATE TABLE IF NOT EXISTS dsh_session_persistence_state (
         singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
         schema_version INTEGER NOT NULL,
@@ -761,9 +761,10 @@ export class DurableObjectSessionPersistence
         title_data TEXT
       ) STRICT`)
       this.syncSummaries()
-      this.repackExistingChunks()
       return `durable-object:store:${storeId}`
     })
+    this.repackExistingChunks()
+    return identity
   }
 
   private repackExistingChunks(): void {
@@ -775,7 +776,8 @@ export class DurableObjectSessionPersistence
       try {
         this.repackOneSession(candidate.id as SessionId)
       } catch (error) {
-        console.error(`dsh-edge: repack failed for session ${candidate.id}`, error)
+        const msg = error instanceof Error ? error.message : String(error)
+        console.error(`dsh-edge: repack failed for session ${candidate.id}: ${msg}`)
       }
     }
   }
@@ -788,23 +790,16 @@ export class DurableObjectSessionPersistence
     ).toArray()
     const events = rows.flatMap(row => rowToEvents(row))
     const packed = packChunkRuns(events)
-    if (packed.length >= rows.length) {
-      // Can't shrink — convert remaining raw chunks to prevent re-selection.
-      // Delete only the assistant/chunk rows and re-insert them as-is (they'll
-      // keep their type but won't match the LIMIT query after packing converts
-      // runs of 3+ into packed rows; isolated chunks stay as-is).
-      // Since packChunkRuns already returned the same count, there's nothing
-      // to do — mark progress by updating one chunk's type won't help.
-      // Instead, just return; the LIMIT 5 loop processes other sessions.
-      return
-    }
-    this.storage.sql.exec(
-      'DELETE FROM dsh_session_events WHERE session_id = ?',
-      id,
-    )
-    for (const record of packed) {
-      this.insertEvent(id, record as SessionEvent)
-    }
+    if (packed.length >= rows.length) return
+    this.storage.transactionSync(() => {
+      this.storage.sql.exec(
+        'DELETE FROM dsh_session_events WHERE session_id = ?',
+        id,
+      )
+      for (const record of packed) {
+        this.insertStorageRecord(id, record)
+      }
+    })
   }
 
   private syncSummaries(): void {
@@ -1051,6 +1046,25 @@ export class DurableObjectSessionPersistence
       envelope.sourceEventSeqs === undefined ? null : JSON.stringify(envelope.sourceEventSeqs),
       envelope.surfaceOp === undefined ? null : JSON.stringify(envelope.surfaceOp),
       event.ignorable === true ? 1 : null,
+    )
+  }
+
+  private insertStorageRecord(id: SessionId, record: Record<string, unknown>): void {
+    const seq = (record.seq ?? record.seq0) as number
+    const time = (record.time ?? record.time0) as number
+    const type = record.type as string
+    this.storage.sql.exec(
+      `INSERT INTO dsh_session_events
+        (session_id, seq, type, time, data, source_event_seqs, surface_op, ignorable)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
+      id,
+      seq,
+      type,
+      time,
+      JSON.stringify(record.data),
+      record.sourceEventSeqs === undefined ? null : JSON.stringify(record.sourceEventSeqs),
+      record.surfaceOp === undefined ? null : JSON.stringify(record.surfaceOp),
+      record.ignorable === true ? 1 : null,
     )
   }
 

--- a/apps/dsh-edge/tests/do-session-persistence.spec.ts
+++ b/apps/dsh-edge/tests/do-session-persistence.spec.ts
@@ -725,3 +725,168 @@ describe('durable-object bounded event pages', () => {
 function isEventPayloadQuery(query: string): boolean {
   return /SELECT seq, type, time, data, source_event_seqs, surface_op, ignorable/u.test(query)
 }
+
+describe('chunk repack on initialization', () => {
+  function chunkEvent(seq: number, turn: number, step: number, chunkType: string, extra: Record<string, unknown> = {}): SessionEvent {
+    return {
+      type: 'assistant/chunk',
+      seq,
+      time: 1000 + seq,
+      data: { turn, step, chunk: { type: chunkType, index: 0, ...extra } },
+    } as SessionEvent
+  }
+
+  it('packs consecutive text-delta chunks on boot', async () => {
+    const storage = new TestDurableObjectStorage()
+    // First boot: create schema + session
+    const ctx = new Context()
+    await ctx.plugin(SessionStore)
+    const id = SessionId('repack-text-deltas')
+    const header: SessionHeader = { id, version: SESSION_FORMAT_VERSION, createdAt: 1 }
+    const fiber = await ctx.plugin(DurableObjectSessionPersistence, { storage: storage as never })
+    const persistence = ctx.sessionPersistence as DurableObjectSessionPersistence
+    try {
+      await persistence.create(header)
+      // Simulate legacy data by inserting unpacked chunks directly into SQL
+      await persistence.append(id, [
+        { type: 'turn/start', seq: 0, time: 1000, data: { turn: 1 } } as SessionEvent,
+        { type: 'step/start', seq: 1, time: 1000, data: { turn: 1, step: 1 } } as SessionEvent,
+      ])
+      // Insert raw assistant/chunk rows to simulate pre-packing data
+      for (const chunk of [
+        chunkEvent(2, 1, 1, 'text-delta', { text: 'hello' }),
+        chunkEvent(3, 1, 1, 'text-delta', { text: ' world' }),
+        chunkEvent(4, 1, 1, 'text-delta', { text: '!' }),
+        chunkEvent(5, 1, 1, 'text-delta', { text: ' How' }),
+      ]) {
+        storage.sql.exec(
+          `INSERT INTO dsh_session_events (session_id, seq, type, time, data) VALUES (?, ?, ?, ?, ?)`,
+          id, chunk.seq, chunk.type, chunk.time, JSON.stringify(chunk.data),
+        )
+      }
+      storage.sql.exec(
+        `INSERT INTO dsh_session_events (session_id, seq, type, time, data) VALUES (?, ?, ?, ?, ?)`,
+        id, 6, 'turn/end', 1006, JSON.stringify({ turn: 1, reason: { kind: 'done' } }),
+      )
+      storage.sql.exec('UPDATE dsh_sessions SET revision = revision + 1 WHERE id = ?', id)
+      await fiber.dispose()
+
+      const beforeChunks = storage.sql.exec<{ cnt: number }>(
+        `SELECT COUNT(*) as cnt FROM dsh_session_events WHERE session_id = ? AND type = 'assistant/chunk'`, id,
+      ).toArray()[0]!.cnt
+      expect(beforeChunks).toBe(4)
+
+      // Second boot: repack should compress the legacy chunks
+      const ctx2 = new Context()
+      await ctx2.plugin(SessionStore)
+      const fiber2 = await ctx2.plugin(DurableObjectSessionPersistence, { storage: storage as never })
+      try {
+        const afterChunks = storage.sql.exec<{ cnt: number }>(
+          `SELECT COUNT(*) as cnt FROM dsh_session_events WHERE session_id = ? AND type = 'assistant/chunk'`, id,
+        ).toArray()[0]!.cnt
+        expect(afterChunks).toBe(0)
+        const packedRows = storage.sql.exec<{ cnt: number }>(
+          `SELECT COUNT(*) as cnt FROM dsh_session_events WHERE session_id = ? AND type = 'text-chunks'`, id,
+        ).toArray()[0]!.cnt
+        expect(packedRows).toBe(1)
+      } finally {
+        await fiber2.dispose()
+      }
+    } finally {
+      storage.close()
+    }
+  })
+
+  it('skips sessions with only isolated non-classifiable chunks', async () => {
+    const storage = new TestDurableObjectStorage()
+    const ctx = new Context()
+    await ctx.plugin(SessionStore)
+    const id = SessionId('repack-block-starts')
+    const header: SessionHeader = { id, version: SESSION_FORMAT_VERSION, createdAt: 1 }
+    const fiber = await ctx.plugin(DurableObjectSessionPersistence, { storage: storage as never })
+    const persistence = ctx.sessionPersistence as DurableObjectSessionPersistence
+    try {
+      await persistence.create(header)
+      await persistence.append(id, [
+        { type: 'turn/start', seq: 0, time: 1000, data: { turn: 1 } } as SessionEvent,
+        { type: 'step/start', seq: 1, time: 1000, data: { turn: 1, step: 1 } } as SessionEvent,
+        chunkEvent(2, 1, 1, 'block-start', { blockType: 'reasoning' }),
+        { type: 'step/end', seq: 3, time: 1003, data: { turn: 1, step: 1 } } as SessionEvent,
+        { type: 'turn/end', seq: 4, time: 1004, data: { turn: 1, reason: { kind: 'interrupted' } } } as SessionEvent,
+      ])
+      await fiber.dispose()
+
+      const beforeRows = storage.sql.exec<{ cnt: number }>(
+        'SELECT COUNT(*) as cnt FROM dsh_session_events WHERE session_id = ?', id,
+      ).toArray()[0]!.cnt
+
+      const ctx2 = new Context()
+      await ctx2.plugin(SessionStore)
+      const fiber2 = await ctx2.plugin(DurableObjectSessionPersistence, { storage: storage as never })
+      try {
+        const afterRows = storage.sql.exec<{ cnt: number }>(
+          'SELECT COUNT(*) as cnt FROM dsh_session_events WHERE session_id = ?', id,
+        ).toArray()[0]!.cnt
+        expect(afterRows).toBe(beforeRows)
+      } finally {
+        await fiber2.dispose()
+      }
+    } finally {
+      storage.close()
+    }
+  })
+
+  it('preserves data when repack insert fails (SAVEPOINT rollback)', async () => {
+    const storage = new TestDurableObjectStorage()
+    const ctx = new Context()
+    await ctx.plugin(SessionStore)
+    const id = SessionId('repack-insert-failure')
+    const header: SessionHeader = { id, version: SESSION_FORMAT_VERSION, createdAt: 1 }
+    const fiber = await ctx.plugin(DurableObjectSessionPersistence, { storage: storage as never })
+    const persistence = ctx.sessionPersistence as DurableObjectSessionPersistence
+    try {
+      await persistence.create(header)
+      await persistence.append(id, [
+        { type: 'turn/start', seq: 0, time: 1000, data: { turn: 1 } } as SessionEvent,
+        { type: 'step/start', seq: 1, time: 1000, data: { turn: 1, step: 1 } } as SessionEvent,
+      ])
+      // Insert raw chunks to simulate legacy data
+      for (const chunk of [
+        chunkEvent(2, 1, 1, 'text-delta', { text: 'a' }),
+        chunkEvent(3, 1, 1, 'text-delta', { text: 'b' }),
+        chunkEvent(4, 1, 1, 'text-delta', { text: 'c' }),
+      ]) {
+        storage.sql.exec(
+          `INSERT INTO dsh_session_events (session_id, seq, type, time, data) VALUES (?, ?, ?, ?, ?)`,
+          id, chunk.seq, chunk.type, chunk.time, JSON.stringify(chunk.data),
+        )
+      }
+      storage.sql.exec(
+        `INSERT INTO dsh_session_events (session_id, seq, type, time, data) VALUES (?, ?, ?, ?, ?)`,
+        id, 5, 'turn/end', 1005, JSON.stringify({ turn: 1, reason: { kind: 'done' } }),
+      )
+      storage.sql.exec('UPDATE dsh_sessions SET revision = revision + 1 WHERE id = ?', id)
+      await fiber.dispose()
+
+      const beforeRows = storage.sql.exec<{ cnt: number }>(
+        'SELECT COUNT(*) as cnt FROM dsh_session_events WHERE session_id = ?', id,
+      ).toArray()[0]!.cnt
+      expect(beforeRows).toBe(6)
+
+      storage.failNextEventInsert()
+      const ctx2 = new Context()
+      await ctx2.plugin(SessionStore)
+      const fiber2 = await ctx2.plugin(DurableObjectSessionPersistence, { storage: storage as never })
+      try {
+        const afterRows = storage.sql.exec<{ cnt: number }>(
+          'SELECT COUNT(*) as cnt FROM dsh_session_events WHERE session_id = ?', id,
+        ).toArray()[0]!.cnt
+        expect(afterRows).toBe(beforeRows)
+      } finally {
+        await fiber2.dispose()
+      }
+    } finally {
+      storage.close()
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Root cause: upstream `packChunkRuns` returns records with `seq0`/`time0` (not `seq`/`time`). `insertEvent` read `event.seq` → `undefined` → SQLite binding error. This caused:
- Every repack attempt to fail silently (catch swallowed the error)
- `appendBatch` with 3+ consecutive packable chunks to crash the turn
- Sessions selected for repack had their events DELETE'd without successful INSERT (data loss)

## Changes

- `insertStorageRecord` method that reads `seq0`/`time0` for packed rows, `seq`/`time` for regular events
- `appendBatch` and `repackOneSession` use `insertStorageRecord` instead of `insertEvent`
- SAVEPOINT isolation: `repackOneSession` uses SAVEPOINT/ROLLBACK TO so a failed INSERT rolls back the DELETE
- Improved error logging: `console.error` shows `error.message` explicitly

## Test plan

- [x] 258 unit tests pass (3 new repack tests)
- [x] Integration tests pass
- [x] Local reproduction confirmed: `packChunkRuns` returns `{seq0, time0}`, `insertStorageRecord` handles both key formats
- [ ] CI passes
- [ ] Deploy and verify repack executes on production DO

🤖 Generated with [Claude Code](https://claude.com/claude-code)