### PR TITLE
release: dsh-edge 0.6.0-alpha.7

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.6.0-alpha.6",
+  "version": "0.6.0-alpha.7",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.6.0-alpha.7.i18n.yaml
+++ b/docs/releases/0.6.0-alpha.7.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.6.0-alpha.7.md: 90aefff80866b90f4f7ee73235af4cdff5da6fd7
+0.6.0-alpha.7.zh.md: 5212ed90f6e87c6082d4215f4af3b229ec9fff05

--- a/docs/releases/0.6.0-alpha.7.md
+++ b/docs/releases/0.6.0-alpha.7.md
@@ -1,0 +1,9 @@
+## dsh-edge 0.6.0-alpha.7
+
+Fixes chunk packing write failures and boot-time repack.
+
+### Fixed
+
+- **Packed record keys**: upstream `packChunkRuns` returns records with `seq0`/`time0` (not `seq`/`time`). New `insertStorageRecord` handles both key formats, fixing write failures for new packed chunks and boot-time repack.
+- **Repack isolation**: each session repacks in its own `transactionSync`, so INSERT failures roll back the DELETE automatically. Prevents data loss from partial repack.
+- **Dead code**: `repackExistingChunks` was after a `return` statement in `initialize()` and never executed. Moved outside the init transaction.

--- a/docs/releases/0.6.0-alpha.7.zh.md
+++ b/docs/releases/0.6.0-alpha.7.zh.md
@@ -1,0 +1,9 @@
+## dsh-edge 0.6.0-alpha.7
+
+修复 chunk 打包写入失败和启动时 repack 问题。
+
+### 修复
+
+- **Packed record 键名**：上游 `packChunkRuns` 返回的记录使用 `seq0`/`time0`（不是 `seq`/`time`）。新增 `insertStorageRecord` 处理两种键名格式，修复新 packed chunk 写入和启动时 repack 的失败。
+- **Repack 隔离**：每个 session 在独立的 `transactionSync` 中 repack，INSERT 失败时 DELETE 自动回滚，防止部分 repack 导致数据丢失。
+- **死代码**：`repackExistingChunks` 在 `initialize()` 的 `return` 语句之后，从未执行。已移到 init 事务之外。


### PR DESCRIPTION
## Summary

- Bump to 0.6.0-alpha.7
- Fixes packed record seq0/time0 keys, repack isolation, dead code

## Test plan

- [ ] CI passes
- [ ] Merge, tag, deploy
- [ ] Verify repack executes: `SELECT COUNT(*) FROM dsh_session_events WHERE type = 'assistant/chunk'` should decrease after cold start

🤖 Generated with [Claude Code](https://claude.com/claude-code)