### PR TITLE
release: dsh-edge 0.6.0-alpha.9

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.6.0-alpha.8",
+  "version": "0.6.0-alpha.9",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.6.0-alpha.9.i18n.yaml
+++ b/docs/releases/0.6.0-alpha.9.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.6.0-alpha.9.md: b2652380f9f98e9ebf1c86d4392eb5266b318a66
+0.6.0-alpha.9.zh.md: 54782ad08a68d1d6947fa6ee4dedb23b9ff51dcc

--- a/docs/releases/0.6.0-alpha.9.md
+++ b/docs/releases/0.6.0-alpha.9.md
@@ -1,0 +1,7 @@
+## dsh-edge 0.6.0-alpha.9
+
+Fixes packed row reading — sessions with packed chunks can now load history.
+
+### Fixed
+
+- **Packed row read**: `rowToEvents` now reconstructs packed rows with `seq0`/`time0` keys (matching upstream `decodeStorageRecord` expectations) instead of `seq`/`time`. Without this, sessions containing packed `text-chunks`/`reasoning-chunks`/`tool-call-chunks` rows failed with "unparsable committed event".

--- a/docs/releases/0.6.0-alpha.9.zh.md
+++ b/docs/releases/0.6.0-alpha.9.zh.md
@@ -1,0 +1,7 @@
+## dsh-edge 0.6.0-alpha.9
+
+修复 packed 行读取 — 包含打包 chunk 的 session 现在能正常加载历史。
+
+### 修复
+
+- **Packed 行读取**：`rowToEvents` 现在使用 `seq0`/`time0` 键名重建 packed 行（匹配上游 `decodeStorageRecord` 的期望），而不是 `seq`/`time`。此前，包含 `text-chunks`/`reasoning-chunks`/`tool-call-chunks` 行的 session 会报 "unparsable committed event" 错误。


### PR DESCRIPTION
## Summary

- Bump to 0.6.0-alpha.9
- Fixes packed row reading: `rowToEvents` uses `seq0`/`time0` for packed rows

## Test plan

- [ ] CI passes
- [ ] Deploy, open a session with packed chunks, verify history loads

🤖 Generated with [Claude Code](https://claude.com/claude-code)