### PR TITLE
release: dsh-edge 0.6.0

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.6.0-alpha.9",
+  "version": "0.6.0",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.6.0.i18n.yaml
+++ b/docs/releases/0.6.0.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.6.0.md: 1b94b235241062d2336d9d15d6b35dba3ad195de
+0.6.0.zh.md: cebf306961e7932b9c25bc380515596036009aac

--- a/docs/releases/0.6.0.md
+++ b/docs/releases/0.6.0.md
@@ -1,0 +1,31 @@
+## dsh-edge 0.6.0
+
+Upstream WorkspaceRegistry migration, multi-workspace support, and streaming chunk packing.
+
+### Added
+
+- **Upstream WorkspaceRegistry**: replaces 339-LOC hand-rolled `EdgeWorkspaceStore` with the upstream cordis plugin. Enables workspace rename, reorder, archive, and crash recovery.
+- **Workspace cwd propagation**: sessions created under a workspace inherit its path as the working directory. The bash tool defaults to the session's cwd.
+- **Edge directory picker**: registers into the upstream `directoryFlow` slot, providing a path input popover with `/workspace/` prefix, validation, and localized strings (en/zh) for workspace creation.
+- **Chunk packing**: `appendBatch` calls upstream `packChunkRuns` before writing, compressing consecutive streaming tokens into packed storage rows (`text-chunks`, `reasoning-chunks`). Matches upstream JSONL persistence behavior.
+- **Session cwd conflict detection**: reusing an existing session ID with a different cwd returns `session-conflict`.
+
+### Fixed
+
+- **Epoch-0 workspace timestamps**: legacy `EdgeWorkspaceStore` wrote `new Date(0)` as `createdAt`; migration now derives timestamps from existing values.
+- **Raised event limit**: `maxEvents` increased from 8,192 to 65,536 decoded events per history page, accommodating sessions with long model output.
+- **System prompt**: no longer hardcodes `/workspace`; each session's bash tool defaults to its own working directory.
+- **Cwd validation**: caller-supplied cwd must be a valid path below `/workspace/`.
+
+### Removed
+
+- `EdgeWorkspaceStore` (339 LOC) — replaced by upstream.
+
+### Technical
+
+- `DurableObjectStorageBackend` maps upstream KV storage interface to DO `ctx.storage`.
+- `insertStorageRecord` handles packed row `seq0`/`time0` keys; `rowToEvents` reconstructs them for `decodeStorageRecord`.
+- Version-bound patch on `dsh-workspace` removes `node:fs/promises` dependency.
+- `ctx.provide()` bridges cordis inject with sub-registry backend registration.
+- WorkspaceRegistry `[Service.init]()` awaited via polling before first access.
+- Blank sessions included in `sessionPersistence.list()` for workspace header indexing.

--- a/docs/releases/0.6.0.zh.md
+++ b/docs/releases/0.6.0.zh.md
@@ -1,0 +1,31 @@
+## dsh-edge 0.6.0
+
+上游 WorkspaceRegistry 迁移、多工作空间支持和流式 chunk 打包。
+
+### 新增
+
+- **上游 WorkspaceRegistry**：用上游 cordis 插件替换 339 行手写的 `EdgeWorkspaceStore`。支持工作空间重命名、排序、归档和崩溃恢复。
+- **Workspace cwd 传播**：在某个工作空间下创建的 session 继承其路径作为工作目录。bash 工具默认使用 session 自身的 cwd。
+- **Edge 目录选择器**：注册到上游 `directoryFlow` slot，提供带 `/workspace/` 前缀的路径输入弹窗，支持校验和本地化字符串（中/英文）。
+- **Chunk 打包**：`appendBatch` 在写入前调用上游 `packChunkRuns`，将连续流式 token 压缩为打包存储行（`text-chunks`、`reasoning-chunks`）。与上游 JSONL 持久化行为一致。
+- **Session cwd 冲突检测**：使用已有 session ID 但指定不同 cwd 时返回 `session-conflict`。
+
+### 修复
+
+- **Epoch-0 工作空间时间戳**：旧版 `EdgeWorkspaceStore` 写入 `new Date(0)` 作为 `createdAt`；迁移现在从现有值推导时间戳。
+- **提高事件限制**：每页历史的 `maxEvents` 从 8,192 提高到 65,536 个解码事件，支持长模型输出的 session。
+- **系统提示词**：不再硬编码 `/workspace`；每个 session 的 bash 工具默认使用其自身的工作目录。
+- **Cwd 校验**：调用方提供的 cwd 必须是 `/workspace/` 下的合法路径。
+
+### 移除
+
+- `EdgeWorkspaceStore`（339 行）— 被上游替代。
+
+### 技术细节
+
+- `DurableObjectStorageBackend` 将上游 KV 存储接口映射到 DO `ctx.storage`。
+- `insertStorageRecord` 处理 packed 行的 `seq0`/`time0` 键；`rowToEvents` 重建它们用于 `decodeStorageRecord`。
+- 版本绑定 patch 移除 `dsh-workspace` 的 `node:fs/promises` 依赖。
+- `ctx.provide()` 桥接 cordis inject 和子注册表 backend 注册。
+- WorkspaceRegistry `[Service.init]()` 通过轮询等待完成后再首次访问。
+- `sessionPersistence.list()` 包含 blank sessions 用于工作空间 header 索引。


### PR DESCRIPTION
## Summary

Stable release of the 0.6.x series: upstream WorkspaceRegistry, multi-workspace cwd, Edge directory picker, and chunk packing.

## Test plan

- [x] All alphas tested on production
- [ ] CI passes
- [ ] Merge, tag `dsh-edge-v0.6.0`, push tag
- [ ] `npm view dsh-edge@0.6.0` resolves on `latest` dist-tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)