### PR TITLE
fix: download workspace files when clicking file links

### DIFF
--- a/packages/client/ui-edge/src/client/index.ts
+++ b/packages/client/ui-edge/src/client/index.ts
@@ -39,7 +39,7 @@ declare module '@deepseek-ai/dsh-client-ui-slots' {
   }
 }
 
-export const inject = ['slots', 'locale', 'settingsScope']
+export const inject = ['slots', 'locale', 'settingsScope', 'workspaces']
 
 export function apply(ctx: ClientContext): void {
   // Edge's API proxy fully supports settings RPCs over the remote transport.
@@ -85,4 +85,17 @@ export function apply(ctx: ClientContext): void {
       )
     }),
   )
+  const workspaces = (ctx as never as { workspaces: { openPath(path: string): Promise<void> } }).workspaces
+  const originalOpenPath = workspaces.openPath.bind(workspaces)
+  workspaces.openPath = async (path: string) => {
+    try {
+      await originalOpenPath(path)
+    } catch {
+      const url = `/api/workspace/file?path=${encodeURIComponent(path)}`
+      const a = document.createElement('a')
+      a.href = url
+      a.download = path.split('/').pop() ?? 'file'
+      a.click()
+    }
+  }
 }

--- a/packages/client/ui-edge/src/client/index.ts
+++ b/packages/client/ui-edge/src/client/index.ts
@@ -92,10 +92,15 @@ export function apply(ctx: ClientContext): void {
       await originalOpenPath(path)
     } catch {
       const url = `/api/workspace/file?path=${encodeURIComponent(path)}`
+      const res = await globalThis.fetch(url)
+      if (!res.ok) throw new Error(`path open failed: ${res.status === 413 ? 'file too large' : await res.text()}`)
+      const blob = await res.blob()
+      const blobUrl = URL.createObjectURL(blob)
       const a = document.createElement('a')
-      a.href = url
+      a.href = blobUrl
       a.download = path.split('/').pop() ?? 'file'
       a.click()
+      URL.revokeObjectURL(blobUrl)
     }
   }
 }

--- a/packages/client/ui-edge/tests/apply.client.spec.ts
+++ b/packages/client/ui-edge/tests/apply.client.spec.ts
@@ -5,7 +5,7 @@ import { EdgeDirectoryFlow } from '../src/client/EdgeDirectoryFlow.tsx'
 
 describe('ui-edge apply', () => {
   it('registers the settings section and directory flow slots', () => {
-    expect(inject).toEqual(['slots', 'locale', 'settingsScope'])
+    expect(inject).toEqual(['slots', 'locale', 'settingsScope', 'workspaces'])
     const entries: Array<{
       options: Record<string, unknown> & { inject?: () => unknown }
       component: unknown
@@ -13,6 +13,7 @@ describe('ui-edge apply', () => {
     const registerLocale = vi.fn()
     const mirror = { persistence: 'memory', load: vi.fn() }
     const ctx = {
+      workspaces: { openPath: vi.fn() },
       settingsScope: { describe: () => mirror },
       effect: (callback: () => unknown) => callback(),
       locale: {


### PR DESCRIPTION
## Summary

Override `ctx.workspaces.openPath` in the Edge client plugin: try the upstream open-in-editor first, on failure fallback to downloading the file via `/api/workspace/file?path=` (already existing endpoint).

Eliminates the "This capability is not available in the Edge runtime" error dialog when clicking file paths in tool results.

## Test plan

- [ ] CI passes
- [ ] Click a file path in a read/write/edit tool result → file downloads instead of error dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)