### PR TITLE
release: dsh-edge 0.7.0-alpha.1

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.6.0",
+  "version": "0.7.0-alpha.1",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.7.0-alpha.1.i18n.yaml
+++ b/docs/releases/0.7.0-alpha.1.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.7.0-alpha.1.md: c040cc443a82de10d6b88896e7f4178e3930057b
+0.7.0-alpha.1.zh.md: dd905ea502044a57ea44f9a5e3bfda9a888f1986

--- a/docs/releases/0.7.0-alpha.1.i18n.yaml
+++ b/docs/releases/0.7.0-alpha.1.i18n.yaml
@@ -2,5 +2,5 @@
 # last confirmed-consistent state. Both languages carry equal authority.
 # After editing either side, update both and re-record every pair with:
 #   pnpm run doc-pairs -- --write
-0.7.0-alpha.1.md: c040cc443a82de10d6b88896e7f4178e3930057b
-0.7.0-alpha.1.zh.md: dd905ea502044a57ea44f9a5e3bfda9a888f1986
+0.7.0-alpha.1.md: 883dbfe444b07c384e452d4f9454e94c132198a9
+0.7.0-alpha.1.zh.md: 01c22d34b5f17389e03c543d3a75359abd5d547a

--- a/docs/releases/0.7.0-alpha.1.md
+++ b/docs/releases/0.7.0-alpha.1.md
@@ -12,5 +12,4 @@ Adds upstream file tools and workspace file download.
 - `EdgeFileSystem` (cordis Service on `ctx.fs`) bridges upstream `FileSystem` abstract class to Computer VFS: resolve, stat, readText, streamText, writeText, editText, readBytes, listDir.
 - `AsyncLocalStorage` scopes VFS bindings per-turn for concurrent session safety.
 - `dsh-sandbox` patch removes `node:fs`/`node:os` imports (canonicalPath returns path directly, VFS has no symlinks).
-- Decoded event limit raised from 8,192 to 65,536 for packed chunk expansion.
 - File download validates HTTP response before triggering save; 413/error responses propagate to the error dialog.

--- a/docs/releases/0.7.0-alpha.1.md
+++ b/docs/releases/0.7.0-alpha.1.md
@@ -1,0 +1,16 @@
+## dsh-edge 0.7.0-alpha.1
+
+Adds upstream file tools and workspace file download.
+
+### Added
+
+- **File tools (read/write/edit/read_image)**: upstream `dsh-tool-fs` adapted via `EdgeFileSystem` backed by Computer VFS. Model gains direct file operations — read with line numbers, write with create/overwrite, str-replace edit with diff output, binary image read. Replaces reliance on bash `cat`/`echo`/`sed` for file operations.
+- **Workspace file download**: clicking file paths in tool results downloads the file via `/api/workspace/file?path=` instead of showing "capability not available" error.
+
+### Technical
+
+- `EdgeFileSystem` (cordis Service on `ctx.fs`) bridges upstream `FileSystem` abstract class to Computer VFS: resolve, stat, readText, streamText, writeText, editText, readBytes, listDir.
+- `AsyncLocalStorage` scopes VFS bindings per-turn for concurrent session safety.
+- `dsh-sandbox` patch removes `node:fs`/`node:os` imports (canonicalPath returns path directly, VFS has no symlinks).
+- Decoded event limit raised from 8,192 to 65,536 for packed chunk expansion.
+- File download validates HTTP response before triggering save; 413/error responses propagate to the error dialog.

--- a/docs/releases/0.7.0-alpha.1.zh.md
+++ b/docs/releases/0.7.0-alpha.1.zh.md
@@ -1,0 +1,16 @@
+## dsh-edge 0.7.0-alpha.1
+
+新增上游文件工具和工作区文件下载。
+
+### 新增
+
+- **文件工具（read/write/edit/read_image）**：上游 `dsh-tool-fs` 通过 `EdgeFileSystem` 适配 Computer VFS。模型获得直接文件操作能力 — 带行号读取、创建/覆盖写入、str-replace 编辑（含 diff 输出）、二进制图片读取。取代对 bash `cat`/`echo`/`sed` 的依赖。
+- **工作区文件下载**：点击工具结果中的文件路径时下载文件（通过 `/api/workspace/file?path=`），而非显示"capability not available"错误。
+
+### 技术细节
+
+- `EdgeFileSystem`（`ctx.fs` cordis Service）桥接上游 `FileSystem` 抽象类到 Computer VFS：resolve、stat、readText、streamText、writeText、editText、readBytes、listDir。
+- `AsyncLocalStorage` 为每个 turn 隔离 VFS 绑定，保证并发 session 安全。
+- `dsh-sandbox` patch 移除 `node:fs`/`node:os` 导入（canonicalPath 直接返回路径，VFS 无 symlink）。
+- 解码事件限制从 8,192 提高到 65,536 以适配 packed chunk 展开。
+- 文件下载在触发保存前校验 HTTP 响应；413/错误响应传递到错误对话框。

--- a/docs/releases/0.7.0-alpha.1.zh.md
+++ b/docs/releases/0.7.0-alpha.1.zh.md
@@ -12,5 +12,4 @@
 - `EdgeFileSystem`（`ctx.fs` cordis Service）桥接上游 `FileSystem` 抽象类到 Computer VFS：resolve、stat、readText、streamText、writeText、editText、readBytes、listDir。
 - `AsyncLocalStorage` 为每个 turn 隔离 VFS 绑定，保证并发 session 安全。
 - `dsh-sandbox` patch 移除 `node:fs`/`node:os` 导入（canonicalPath 直接返回路径，VFS 无 symlink）。
-- 解码事件限制从 8,192 提高到 65,536 以适配 packed chunk 展开。
 - 文件下载在触发保存前校验 HTTP 响应；413/错误响应传递到错误对话框。


### PR DESCRIPTION
## Summary

- Bump to 0.7.0-alpha.1
- Bilingual release notes for file tools + file download

## Test plan

- [ ] CI passes
- [ ] Merge, tag, push tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)