### PR TITLE
release: dsh-edge 0.7.0-alpha.2

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.7.0-alpha.1",
+  "version": "0.7.0-alpha.2",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.7.0-alpha.2.i18n.yaml
+++ b/docs/releases/0.7.0-alpha.2.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.7.0-alpha.2.md: cad2d4238f4914a1f25aabce54544525d6c69646
+0.7.0-alpha.2.zh.md: 42c2b0390e4f8e54ad4b05e64e46eddf577095fa

--- a/docs/releases/0.7.0-alpha.2.md
+++ b/docs/releases/0.7.0-alpha.2.md
@@ -1,0 +1,9 @@
+## dsh-edge 0.7.0-alpha.2
+
+Adds goal tracking tools for multi-round autonomous objectives.
+
+### Added
+
+- **Goal tools (create_goal/get_goal/update_goal)**: upstream `GoalService` + `ToolGoal` + `GoalRoundDriver` cordis plugins. Model can create completion objectives, track progress, and autonomously continue across multiple turns.
+- **Goal UI**: `dsh-client-ui-goal` now included in the assembled client (33 plugins). Shows goal progress bar in the input dock and goal change nodes in conversation.
+- **Goals RPC**: all six methods (create/edit/pause/resume/complete/clear) wired to delegate to GoalService instead of returning unsupported.

--- a/docs/releases/0.7.0-alpha.2.zh.md
+++ b/docs/releases/0.7.0-alpha.2.zh.md
@@ -1,0 +1,9 @@
+## dsh-edge 0.7.0-alpha.2
+
+新增目标追踪工具，支持多轮自主完成目标。
+
+### 新增
+
+- **目标工具（create_goal/get_goal/update_goal）**：上游 `GoalService` + `ToolGoal` + `GoalRoundDriver` cordis 插件。模型可以创建完成目标、追踪进度、跨多轮自主续跑。
+- **目标 UI**：`dsh-client-ui-goal` 现已包含在组装的客户端中（33 个插件）。在输入区显示目标进度条，在会话中显示目标变更节点。
+- **Goals RPC**：全部六个方法（create/edit/pause/resume/complete/clear）从 unsupported 改为委托 GoalService。


### PR DESCRIPTION
## Summary

- Bump to 0.7.0-alpha.2
- Bilingual release notes for goal tracking tools

## Test plan

- [ ] CI passes
- [ ] Merge, tag, push tag

🤖 Generated with [Claude Code](https://claude.com/claude-code)