### PR TITLE
docs: add Git and worktree hygiene rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,4 +91,4 @@ git pull                                                  # 4. sync main
 ```
 
 - Automated tools may create worktrees under `.claude/worktrees/`. If not auto-cleaned, verify the worktree is clean or its PR was merged before removing. Unlock if locked: `git worktree unlock <path>`, then `git worktree remove <path>`.
-- Before starting a new iteration, verify a clean state: `git worktree list` shows only the primary checkout, `git branch --show-current` returns `main`, and `git branch --merged main | grep -v main` is empty.
+- Before starting a new iteration, verify a clean state: `git worktree list` shows only the primary checkout, `git branch --show-current` returns `main`, and `git branch` lists only `main`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -77,7 +77,7 @@ mkdir -p ../dsh-edge-worktrees
 git worktree add ../dsh-edge-worktrees/<slug> -b <branch> main
 cd ../dsh-edge-worktrees/<slug>
 pnpm install
-pnpm --dir apps/dsh-edge/standalone install
+pnpm --dir apps/dsh-edge/standalone install --frozen-lockfile
 ```
 
 - After a PR is merged, clean up completely — worktree directory, local branch, and remote branch:
@@ -85,10 +85,10 @@ pnpm --dir apps/dsh-edge/standalone install
 ```sh
 cd /path/to/dsh-edge                                     # return to primary checkout
 git worktree remove ../dsh-edge-worktrees/<slug>          # 1. remove worktree
-git branch -d <branch>                                    # 2. delete local branch
+git branch -D <branch>                                    # 2. delete local branch (-D for squash-merged PRs)
 git push origin --delete <branch>                         # 3. delete remote branch (skip if GitHub auto-delete is on)
 git pull                                                  # 4. sync main
 ```
 
-- Automated tools may create worktrees under `.claude/worktrees/`. If not auto-cleaned, apply the same three-step removal. Unlock first if locked: `git worktree unlock <path>`, then `git worktree remove <path> --force`.
+- Automated tools may create worktrees under `.claude/worktrees/`. If not auto-cleaned, verify the worktree is clean or its PR was merged before removing. Unlock if locked: `git worktree unlock <path>`, then `git worktree remove <path>`.
 - Before starting a new iteration, verify a clean state: `git worktree list` shows only the primary checkout, `git branch --show-current` returns `main`, and `git branch --merged main | grep -v main` is empty.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -66,3 +66,29 @@ Every version published to npm must also have a matching GitHub Release and git 
 The workflow can also be triggered manually via `request-release.yml` (workflow_dispatch) or `repository_dispatch` as a fallback. Prerelease versions (containing `-`) are published to the `next` npm dist-tag and marked as GitHub prerelease.
 
 Stage, commit, push, PR creation, review replies, thread resolution, releases, tags, npm publication, and Cloudflare deployment require the corresponding user authorization.
+
+## Git and worktree hygiene
+
+- The primary checkout stays on `main`. Use it only for pulling, global builds, and small documentation edits that do not need a PR.
+- All feature, fix, and release work happens in an isolated worktree:
+
+```sh
+mkdir -p ../dsh-edge-worktrees
+git worktree add ../dsh-edge-worktrees/<slug> -b <branch> main
+cd ../dsh-edge-worktrees/<slug>
+pnpm install
+pnpm --dir apps/dsh-edge/standalone install
+```
+
+- After a PR is merged, clean up completely — worktree directory, local branch, and remote branch:
+
+```sh
+cd /path/to/dsh-edge                                     # return to primary checkout
+git worktree remove ../dsh-edge-worktrees/<slug>          # 1. remove worktree
+git branch -d <branch>                                    # 2. delete local branch
+git push origin --delete <branch>                         # 3. delete remote branch (skip if GitHub auto-delete is on)
+git pull                                                  # 4. sync main
+```
+
+- Automated tools may create worktrees under `.claude/worktrees/`. If not auto-cleaned, apply the same three-step removal. Unlock first if locked: `git worktree unlock <path>`, then `git worktree remove <path> --force`.
+- Before starting a new iteration, verify a clean state: `git worktree list` shows only the primary checkout, `git branch --show-current` returns `main`, and `git branch --merged main | grep -v main` is empty.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,5 +90,5 @@ git push origin --delete <branch>                         # 3. delete remote bra
 git pull                                                  # 4. sync main
 ```
 
-- Automated tools may create worktrees under `.claude/worktrees/`. If not auto-cleaned, verify the worktree is clean or its PR was merged before removing. Unlock if locked: `git worktree unlock <path>`, then `git worktree remove <path>`.
+- Automated tools may create their own worktrees. If not auto-cleaned, verify the worktree is clean or its PR was merged before removing. Unlock if locked: `git worktree unlock <path>`, then `git worktree remove <path>`.
 - Before starting a new iteration, verify a clean state: `git worktree list` shows only the primary checkout, `git branch --show-current` returns `main`, and `git branch` lists only `main`.


### PR DESCRIPTION
## Summary

Add worktree-based development workflow and branch cleanup rules to AGENTS.md.

- Primary checkout stays on `main` — all work in isolated worktrees under `../dsh-edge-worktrees/`
- Three-step cleanup after PR merge: worktree directory + local branch + remote branch
- Automated worktree cleanup rules
- Pre-iteration clean state verification

**1 file changed**: `AGENTS.md` (+26 lines)

🤖 Generated with [Claude Code](https://claude.com/claude-code)