### PR TITLE
release: dsh-edge 0.7.0-alpha.3

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.7.0-alpha.2",
+  "version": "0.7.0-alpha.3",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -271,6 +271,9 @@ export class EdgeSessionStore {
     await this.context.plugin(TypertGatewayService)
     await this.context.plugin(ToolFs)
     await this.context.plugin(GoalService)
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const { TYPERT: GOAL_TYPERT } = await import('@deepseek-ai/dsh-goal/typert' as string)
+    this.context.typert.register(GOAL_TYPERT as never)
     await this.context.plugin(ToolGoal)
     await this.context.plugin(GoalRoundDriver)
     await this.context.plugin(SpillPolicy, { maxInlineBytes: 32_768 })

--- a/docs/releases/0.7.0-alpha.3.i18n.yaml
+++ b/docs/releases/0.7.0-alpha.3.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.7.0-alpha.3.md: 6d598d526c117bba83bee1bd410118d3432cc576
+0.7.0-alpha.3.zh.md: 02486de77c3d7c7e18c2e08c575fc3a2ce1d3994

--- a/docs/releases/0.7.0-alpha.3.md
+++ b/docs/releases/0.7.0-alpha.3.md
@@ -1,0 +1,21 @@
+## dsh-edge 0.7.0-alpha.3
+
+Goal UI fully functional: projection bridge + Typert host-side gateway.
+
+### Added
+
+- **Session projection bridge**: generic `SessionProjectionRegistry.onChanged()` listener synchronously captures projection changes and delivers them after flush. Goal, title, and future projection keys are pushed to the client automatically.
+- **Typert host-side gateway**: `TypertRegistry` + `TypertGatewayService` upstream cordis plugins installed for automatic RPC dispatch. GoalService's `@Remote`-decorated methods (`edit`, `pause`, `resume`, `complete`, `clear`, `create`) are discovered via SRC and routed without per-method adapter code.
+- **Goal strict descriptors**: `dsh-goal/typert` host contribution registered so the gateway resolves wire parameter names (`agentId` → `agent`) correctly.
+- **Reconnect baseline**: `summaryProjections()` merges `SessionProjectionRegistry.snapshot()` values so goal state survives page reload.
+
+### Fixed
+
+- **GoalBar not visible**: projection frames for `goal/change` events were computed by the registry but never pushed to the client.
+- **GoalBar buttons (edit/pause/clear) failing**: Typert remote RPC path (`/api/goals/edit`) was not routed — only the apiproxy path (`/api/goal.edit`) was handled.
+- **Projection flush ordering**: projections are captured synchronously at event time and drained only after the matching event's flush, preventing pre-durable state from reaching the client.
+
+### Dependencies
+
+- Added `@deepseek-ai/dsh-api-gateway`, `@deepseek-ai/dsh-typert-protocol`, `@deepseek-ai/dsh-typert-registry` (upstream 0.1.1-rc.2).
+- Patch: `dsh-api-gateway` — defer module-level `AbortController` creation (Cloudflare Workers global-scope restriction).

--- a/docs/releases/0.7.0-alpha.3.zh.md
+++ b/docs/releases/0.7.0-alpha.3.zh.md
@@ -1,0 +1,21 @@
+## dsh-edge 0.7.0-alpha.3
+
+Goal UI 完整可用：projection 桥接 + Typert host-side gateway。
+
+### 新增
+
+- **Session projection 桥接**：通过 `SessionProjectionRegistry.onChanged()` 同步捕获 projection 变更并在 flush 后推送。goal、title 及未来的 projection key 自动推送给客户端。
+- **Typert host-side gateway**：安装上游 `TypertRegistry` + `TypertGatewayService` cordis 插件，自动路由 RPC。GoalService 的 `@Remote` 方法（edit/pause/resume/complete/clear/create）通过 SRC 反射自动发现和路由，无需手写 adapter。
+- **Goal 严格 descriptor**：注册 `dsh-goal/typert` host 贡献，使 gateway 正确解析 wire 参数名（`agentId` → `agent`）。
+- **重连 baseline**：`summaryProjections()` 合并 `SessionProjectionRegistry.snapshot()` 的值，goal 状态在页面刷新后保留。
+
+### 修复
+
+- **GoalBar 不显示**：`goal/change` 事件的 projection 值由 registry 计算但从未推送给客户端。
+- **GoalBar 按钮（edit/pause/clear）失败**：Typert remote RPC 路径（`/api/goals/edit`）未路由，只有 apiproxy 路径（`/api/goal.edit`）可用。
+- **Projection flush 时序**：projection 在事件发生时同步捕获，仅在对应事件 flush 后才推送，防止未持久化的状态到达客户端。
+
+### 依赖
+
+- 新增 `@deepseek-ai/dsh-api-gateway`、`@deepseek-ai/dsh-typert-protocol`、`@deepseek-ai/dsh-typert-registry`（上游 0.1.1-rc.2）。
+- Patch：`dsh-api-gateway` — 延迟模块级 `AbortController` 构造（Cloudflare Workers 全局作用域限制）。


### PR DESCRIPTION
## Summary

- Register goal strict Typert host descriptors for correct wire parameter mapping (`agentId` → `agent`)
- Bump version to 0.7.0-alpha.3
- Add bilingual release notes

Builds on #83 (projection bridge) and #85 (Typert gateway). Together these three PRs deliver full goal UI functionality:
- GoalBar displays during active goals
- GoalBar edit/pause/resume/clear buttons work
- Goal state survives page reload

## Test plan

- [x] Verified locally: GoalBar appears, edit/pause/clear all functional
- [ ] CI passes
- [ ] npm publish via release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)