### PR TITLE
release: dsh-edge 0.7.0

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.7.0-alpha.3",
+  "version": "0.7.0",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.7.0.i18n.yaml
+++ b/docs/releases/0.7.0.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.7.0.md: c7349e1cd00cb37f85051b0215043dc14e2de797
+0.7.0.zh.md: 1e85d73bcf957744a9add7432fa3225be742f8eb

--- a/docs/releases/0.7.0.md
+++ b/docs/releases/0.7.0.md
@@ -1,0 +1,31 @@
+## dsh-edge 0.7.0
+
+File tools, goal tracking, and full goal UI support.
+
+### Added
+
+- **File tools (read/write/edit/read_image)**: upstream `dsh-tool-fs` adapted via `EdgeFileSystem` backed by Computer VFS. Model gains direct file operations — read with line numbers, write with create/overwrite, str-replace edit with diff output, binary image read.
+- **Workspace file download**: clicking file paths in tool results downloads the file via `/api/workspace/file?path=` instead of showing "capability not available" error.
+- **Goal tools (create_goal/get_goal/update_goal)**: upstream `GoalService` + `ToolGoal` + `GoalRoundDriver` cordis plugins. Model can create completion objectives, track progress, and autonomously continue across multiple turns.
+- **Goal UI**: `dsh-client-ui-goal` included in the assembled client (33 plugins). Shows GoalBar with pause/edit/clear controls in the input dock and goal change nodes in conversation.
+- **Session projection bridge**: generic `SessionProjectionRegistry.onChanged()` listener synchronously captures projection changes and delivers them after flush. Goal, title, and future projection keys are pushed to the client automatically.
+- **Typert host-side gateway**: `TypertRegistry` + `TypertGatewayService` upstream cordis plugins for automatic RPC dispatch. GoalService's `@Remote`-decorated methods are discovered via SRC and routed without per-method adapter code. GoalBar edit/pause/clear buttons work via the Typert RPC path.
+- **Cold-session projection cache**: projection snapshots persist to Durable Object KV storage on `turn/end` and `goal/change` events. Cold sessions serve the cached goal state in the history baseline without agent reactivation.
+
+### Fixed
+
+- **GoalBar not visible**: projection frames for `goal/change` events were computed by the registry but never pushed to the client.
+- **GoalBar buttons (edit/pause/clear) failing**: Typert remote RPC path (`/api/goals/edit`) was not routed — only the apiproxy path (`/api/goal.edit`) was handled.
+- **Cold-session goal state lost**: after DO restart, sessions without a live agent now serve goal projection from the KV cache baseline instead of returning an empty projection block.
+
+### Technical
+
+- `EdgeFileSystem` (cordis Service on `ctx.fs`) bridges upstream `FileSystem` abstract class to Computer VFS with `AsyncLocalStorage` for concurrent session safety.
+- `dsh-sandbox` patch removes `node:fs`/`node:os` imports (VFS has no symlinks).
+- `dsh-api-gateway` patch defers module-level `AbortController` creation (Cloudflare Workers global-scope restriction).
+- Projection delivery uses synchronous capture + seq-matched deferred drain to ensure projections arrive after their backing events are durable.
+- Reconnect baseline merges `SessionProjectionRegistry.snapshot()` values into `summaryProjections()`.
+
+### Dependencies
+
+- Added `@deepseek-ai/dsh-api-gateway`, `@deepseek-ai/dsh-typert-protocol`, `@deepseek-ai/dsh-typert-registry` (upstream 0.1.1-rc.2).

--- a/docs/releases/0.7.0.zh.md
+++ b/docs/releases/0.7.0.zh.md
@@ -1,0 +1,31 @@
+## dsh-edge 0.7.0
+
+文件工具、目标追踪及完整的目标 UI 支持。
+
+### 新增
+
+- **文件工具（read/write/edit/read_image）**：通过 `EdgeFileSystem` 适配上游 `dsh-tool-fs`，底层对接 Computer VFS。模型获得直接的文件操作能力——带行号读取、创建/覆盖写入、字符串替换编辑（含 diff 输出）、二进制图片读取。
+- **工作区文件下载**：点击工具结果中的文件路径可通过 `/api/workspace/file?path=` 下载文件，不再提示"capability not available"。
+- **目标工具（create_goal/get_goal/update_goal）**：上游 `GoalService` + `ToolGoal` + `GoalRoundDriver` cordis 插件。模型可以创建完成目标、追踪进度、跨多轮自主续跑。
+- **目标 UI**：`dsh-client-ui-goal` 包含在组装的客户端中（33 个插件）。在输入区显示 GoalBar，带暂停/编辑/清除控件，在会话中显示目标变更节点。
+- **会话投影桥接**：通过 `SessionProjectionRegistry.onChanged()` 监听器同步捕获投影变更，在 flush 之后推送给客户端。Goal、title 及未来的投影键自动推送。
+- **Typert 宿主侧网关**：安装 `TypertRegistry` + `TypertGatewayService` 上游 cordis 插件，自动路由 RPC 调用。GoalService 的 `@Remote` 装饰方法通过 SRC 发现并路由，无需为每个方法编写适配器。GoalBar 的编辑/暂停/清除按钮通过 Typert RPC 路径生效。
+- **冷会话投影缓存**：投影快照在 `turn/end` 和 `goal/change` 事件时持久化到 Durable Object KV 存储。冷会话在历史 baseline 中直接提供缓存的目标状态，无需重新激活 agent。
+
+### 修复
+
+- **GoalBar 不显示**：`goal/change` 事件的投影帧由注册表计算但从未推送给客户端。
+- **GoalBar 按钮（编辑/暂停/清除）失败**：Typert remote RPC 路径（`/api/goals/edit`）未被路由——仅处理了 apiproxy 路径（`/api/goal.edit`）。
+- **冷会话目标状态丢失**：DO 重启后，没有活跃 agent 的会话现在从 KV 缓存 baseline 提供目标投影，而非返回空投影块。
+
+### 技术细节
+
+- `EdgeFileSystem`（cordis Service `ctx.fs`）桥接上游 `FileSystem` 抽象类至 Computer VFS，使用 `AsyncLocalStorage` 确保并发会话安全。
+- `dsh-sandbox` 补丁移除 `node:fs`/`node:os` 导入（VFS 无符号链接）。
+- `dsh-api-gateway` 补丁延迟模块级 `AbortController` 创建（Cloudflare Workers 全局作用域限制）。
+- 投影推送使用同步捕获 + 按 seq 匹配的延迟 drain，确保投影在其对应事件持久化之后才到达客户端。
+- 重连 baseline 将 `SessionProjectionRegistry.snapshot()` 的值合并到 `summaryProjections()` 中。
+
+### 依赖
+
+- 新增 `@deepseek-ai/dsh-api-gateway`、`@deepseek-ai/dsh-typert-protocol`、`@deepseek-ai/dsh-typert-registry`（上游 0.1.1-rc.2）。


### PR DESCRIPTION
## Summary

- Bump version to 0.7.0 (from 0.7.0-alpha.3)
- Add bilingual release notes consolidating all 0.7.0 alpha work

### What's in 0.7.0

**File tools**: `EdgeFileSystem` + `dsh-tool-fs` — model gains read/write/edit/read_image via Computer VFS  
**Goal tracking**: `GoalService` + `ToolGoal` + `GoalRoundDriver` — multi-round autonomous objectives  
**Goal UI**: GoalBar with pause/edit/clear controls, fully functional via Typert RPC gateway  
**Projection bridge**: generic `onChanged` listener for all current and future projection keys  
**Cold-session cache**: DO KV projection snapshots survive DO restart  

### PRs included since 0.6.0

- #73 EdgeFileSystem + file tools
- #74 Workspace file download
- #78 Goal tools (create_goal/get_goal/update_goal)
- #83 Projection bridge (onChanged listener)
- #85 Typert host-side gateway
- #87 Cold-session projection cache

## Test plan

- [x] Local dev server tested with goal create/edit/pause/clear
- [x] Cold session tested (server restart → GoalBar persists)
- [x] 255/255 unit tests pass
- [x] Integration tests pass
- [x] Bundle size: 773,848 / 921,600 bytes gzip

🤖 Generated with [Claude Code](https://claude.com/claude-code)