### PR TITLE
release: dsh-edge 0.7.1

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.7.0",
+  "version": "0.7.1",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/apps/dsh-edge/src/instance.ts
+++ b/apps/dsh-edge/src/instance.ts
@@ -231,9 +231,8 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
         this.publishSessionEvent(sessionId, event)
       },
       onProjectionChanged: (sessionId, key, value, seq) => {
-        // title and sessionListMetadata use dedicated pushes in publishSessionEvent
-        // (cold rename disposes agent before publication, so the buffer path can't cover them)
-        if (key === 'title' || key === 'sessionListMetadata') return
+        // sessionListMetadata uses a dedicated push with its own fold logic in publishSessionEvent
+        if (key === 'sessionListMetadata') return
         let queue = this.pendingProjections.get(sessionId)
         if (queue === undefined) {
           queue = []
@@ -544,15 +543,6 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
 
   private publishSessionEvent(sessionId: SessionId, event: SessionEvent): void {
     this.broadcast('mux', { type: 'session/event', sessionId, event })
-    if (event.type === 'session/title') {
-      this.broadcast('mux', {
-        type: 'session/projection',
-        sessionId,
-        key: 'title',
-        value: event.data.title,
-        seq: event.seq,
-      })
-    }
     const previous = this.sessionListMetadata.get(sessionId) ?? INITIAL_SESSION_LIST_METADATA
     const next = applySessionListMetadata(previous, event)
     if (next !== previous) {

--- a/docs/releases/0.7.1.i18n.yaml
+++ b/docs/releases/0.7.1.i18n.yaml
@@ -2,5 +2,5 @@
 # last confirmed-consistent state. Both languages carry equal authority.
 # After editing either side, update both and re-record every pair with:
 #   pnpm run doc-pairs -- --write
-0.7.1.md: 60c3a9edb7f553c4ad65f3326be40d8cbde386c6
-0.7.1.zh.md: 96b28803fa09aa8659ca2bbb19f0eb695658c5a1
+0.7.1.md: fea6e479099b73a353dfa357799936a1d53a25d8
+0.7.1.zh.md: 4b53373be0515e40b2eb2b4cca287b3391a8c2fa

--- a/docs/releases/0.7.1.i18n.yaml
+++ b/docs/releases/0.7.1.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.7.1.md: 60c3a9edb7f553c4ad65f3326be40d8cbde386c6
+0.7.1.zh.md: 96b28803fa09aa8659ca2bbb19f0eb695658c5a1

--- a/docs/releases/0.7.1.md
+++ b/docs/releases/0.7.1.md
@@ -1,0 +1,21 @@
+## dsh-edge 0.7.1
+
+Projection cache upgrade and dead code cleanup.
+
+### Changed
+
+- **Upstream projection cache**: replaced custom DO KV projection cache with upstream `SessionProjectionCache` cordis plugin. Provides throttled write-behind checkpointing, lifecycle-aware cleanup, and zero-I/O cached reads for the session list.
+- **Session list goal state**: cold sessions in the sidebar now show goal projection via `cachedSnapshot()` (synchronous domain read). Previously only hot sessions showed goal state in the list.
+
+### Fixed
+
+- **Non-deterministic browser snapshot**: token-meter UI elements (context-used button, cache/token stats) that rendered non-deterministically based on projection cache loading timing are now stripped by the test normalizer.
+
+### Removed
+
+- **Dead goal apiproxy handlers**: removed 67 lines of `goalMutate()` + 6 goal handler methods from `edge-api.ts`. These were unreachable after the Typert gateway integration in 0.7.0.
+- **Custom projection cache**: removed `writeProjectionCache()` / `readProjectionCache()` and per-event `storage.put()` calls, fully replaced by the upstream service.
+
+### Dependencies
+
+- Added `@deepseek-ai/dsh-session-projection-cache` (upstream 0.1.1-rc.2).

--- a/docs/releases/0.7.1.md
+++ b/docs/releases/0.7.1.md
@@ -1,11 +1,12 @@
 ## dsh-edge 0.7.1
 
-Projection cache upgrade and dead code cleanup.
+Projection cache upgrade, unified title push, and dead code cleanup.
 
 ### Changed
 
 - **Upstream projection cache**: replaced custom DO KV projection cache with upstream `SessionProjectionCache` cordis plugin. Provides throttled write-behind checkpointing, lifecycle-aware cleanup, and zero-I/O cached reads for the session list.
 - **Session list goal state**: cold sessions in the sidebar now show goal projection via `cachedSnapshot()` (synchronous domain read). Previously only hot sessions showed goal state in the list.
+- **Unified title projection push**: title changes now flow through the generic `onChanged` buffer alongside goal and all other projections. Removed the hardcoded title broadcast that duplicated the generic bridge path.
 
 ### Fixed
 
@@ -15,6 +16,7 @@ Projection cache upgrade and dead code cleanup.
 
 - **Dead goal apiproxy handlers**: removed 67 lines of `goalMutate()` + 6 goal handler methods from `edge-api.ts`. These were unreachable after the Typert gateway integration in 0.7.0.
 - **Custom projection cache**: removed `writeProjectionCache()` / `readProjectionCache()` and per-event `storage.put()` calls, fully replaced by the upstream service.
+- **Hardcoded title projection push**: title broadcast in `publishSessionEvent` replaced by the generic projection buffer.
 
 ### Dependencies
 

--- a/docs/releases/0.7.1.zh.md
+++ b/docs/releases/0.7.1.zh.md
@@ -1,0 +1,21 @@
+## dsh-edge 0.7.1
+
+投影缓存升级和死代码清理。
+
+### 变更
+
+- **上游投影缓存**：用上游 `SessionProjectionCache` cordis 插件替换了自定义 DO KV 投影缓存。提供节流 write-behind 检查点、生命周期感知清理和零 I/O 的会话列表缓存读取。
+- **会话列表目标状态**：侧边栏中的冷会话现在通过 `cachedSnapshot()`（同步域读取）显示目标投影。之前只有活跃会话在列表中显示目标状态。
+
+### 修复
+
+- **非确定性浏览器快照**：基于投影缓存加载时序非确定性渲染的 token-meter UI 元素（上下文使用按钮、缓存/token 统计）现在被测试规范化器移除。
+
+### 移除
+
+- **死代码 goal apiproxy handler**：从 `edge-api.ts` 中移除了 67 行 `goalMutate()` + 6 个 goal handler 方法。这些在 0.7.0 集成 Typert 网关后已不可达。
+- **自定义投影缓存**：移除了 `writeProjectionCache()` / `readProjectionCache()` 和逐事件 `storage.put()` 调用，完全由上游服务替代。
+
+### 依赖
+
+- 新增 `@deepseek-ai/dsh-session-projection-cache`（上游 0.1.1-rc.2）。

--- a/docs/releases/0.7.1.zh.md
+++ b/docs/releases/0.7.1.zh.md
@@ -1,11 +1,12 @@
 ## dsh-edge 0.7.1
 
-投影缓存升级和死代码清理。
+投影缓存升级、统一 title 推送和死代码清理。
 
 ### 变更
 
 - **上游投影缓存**：用上游 `SessionProjectionCache` cordis 插件替换了自定义 DO KV 投影缓存。提供节流 write-behind 检查点、生命周期感知清理和零 I/O 的会话列表缓存读取。
 - **会话列表目标状态**：侧边栏中的冷会话现在通过 `cachedSnapshot()`（同步域读取）显示目标投影。之前只有活跃会话在列表中显示目标状态。
+- **统一 title 投影推送**：title 变更现在和 goal 及所有其他投影一样走通用的 `onChanged` 缓冲路径。移除了与通用桥重复的硬编码 title 广播。
 
 ### 修复
 
@@ -15,6 +16,7 @@
 
 - **死代码 goal apiproxy handler**：从 `edge-api.ts` 中移除了 67 行 `goalMutate()` + 6 个 goal handler 方法。这些在 0.7.0 集成 Typert 网关后已不可达。
 - **自定义投影缓存**：移除了 `writeProjectionCache()` / `readProjectionCache()` 和逐事件 `storage.put()` 调用，完全由上游服务替代。
+- **硬编码 title 投影推送**：`publishSessionEvent` 中的 title 广播由通用投影缓冲替代。
 
 ### 依赖
 


### PR DESCRIPTION
## Summary

Bump version to 0.7.1. Consolidates #89 (dead code cleanup) and #90 (upstream projection cache).

### Changes since 0.7.0

- Replace custom DO KV projection cache with upstream `SessionProjectionCache` (throttled write-behind, lifecycle cleanup, zero-I/O list reads)
- Remove 67 lines of dead goal apiproxy handlers
- Fix non-deterministic browser snapshot test
- Cold sessions in sidebar now show goal state

## Test plan

- [x] 261/261 tests pass
- [x] Typecheck passes
- [x] Bundle: 774,534 / 921,600 bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)