### PR TITLE
feat: enable message feedback

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -7,7 +7,7 @@
 
 ## DeepSeek Harness
 
-`dsh-edge` assembles published DeepSeek Harness packages and applies 7 version-bound adaptations to the pinned `0.1.1-rc.2` release. DeepSeek Harness remains under its upstream MIT license:
+`dsh-edge` assembles published DeepSeek Harness packages and applies 8 version-bound adaptations to the pinned `0.1.1-rc.2` release. DeepSeek Harness remains under its upstream MIT license:
 
 ```text
 MIT License

--- a/apps/dsh-edge/THIRD_PARTY_NOTICES.md
+++ b/apps/dsh-edge/THIRD_PARTY_NOTICES.md
@@ -7,7 +7,7 @@
 
 ## DeepSeek Harness
 
-`dsh-edge` assembles published DeepSeek Harness packages and applies 7 version-bound adaptations to the pinned `0.1.1-rc.2` release. DeepSeek Harness remains under its upstream MIT license:
+`dsh-edge` assembles published DeepSeek Harness packages and applies 8 version-bound adaptations to the pinned `0.1.1-rc.2` release. DeepSeek Harness remains under its upstream MIT license:
 
 ```text
 MIT License

--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -92,6 +92,7 @@
     "@deepseek-ai/dsh-launch-environment": "0.1.1-rc.2",
     "@deepseek-ai/dsh-llm": "0.1.1-rc.2",
     "@deepseek-ai/dsh-llm-deepseek": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-message-feedback": "0.1.1-rc.2",
     "@deepseek-ai/dsh-session": "0.1.1-rc.2",
     "@deepseek-ai/dsh-session-persistence": "0.1.1-rc.2",
     "@deepseek-ai/dsh-session-projection": "0.1.1-rc.2",

--- a/apps/dsh-edge/src/do-message-feedback-store.ts
+++ b/apps/dsh-edge/src/do-message-feedback-store.ts
@@ -1,0 +1,63 @@
+/** Point-read Durable Object storage for upstream message feedback rows. */
+
+import {
+  messageFeedbackRowSchema,
+  type MessageFeedbackRow,
+  type MessageFeedbackStore,
+} from '@deepseek-ai/dsh-message-feedback'
+import { StorageError } from '@deepseek-ai/dsh-storage'
+
+const MESSAGE_FEEDBACK_UNIT = 'message_feedback'
+const MESSAGE_FEEDBACK_VERSION = 0
+const VERSION_KEY = `dsh-kv:${MESSAGE_FEEDBACK_UNIT}:__version__`
+const RECORD_PREFIX = `dsh-kv:${MESSAGE_FEEDBACK_UNIT}:sessions:`
+
+function recordKey(sessionId: string): string {
+  return `${RECORD_PREFIX}${sessionId}`
+}
+
+/**
+ * Preserves the storage-domain key schema without materializing every retained
+ * feedback row when a Durable Object starts.
+ */
+export class DurableObjectMessageFeedbackStore implements MessageFeedbackStore {
+  private readonly ready: Promise<void>
+
+  constructor(private readonly storage: DurableObjectStorage) {
+    this.ready = this.ensureVersion()
+  }
+
+  async get(sessionId: string): Promise<MessageFeedbackRow | undefined> {
+    await this.ready
+    const value = await this.storage.get(recordKey(sessionId))
+    if (value === undefined) return undefined
+    const parsed = messageFeedbackRowSchema.safeParse(value)
+    if (!parsed.success) {
+      throw new StorageError(
+        'malformed-medium',
+        `message feedback row '${sessionId}' does not match its schema`,
+        { cause: parsed.error },
+      )
+    }
+    return parsed.data
+  }
+
+  async put(sessionId: string, row: MessageFeedbackRow): Promise<void> {
+    await this.ready
+    await this.storage.put(recordKey(sessionId), row)
+  }
+
+  private async ensureVersion(): Promise<void> {
+    const storedVersion = await this.storage.get(VERSION_KEY)
+    if (storedVersion === undefined) {
+      await this.storage.put(VERSION_KEY, MESSAGE_FEEDBACK_VERSION)
+      return
+    }
+    if (storedVersion !== MESSAGE_FEEDBACK_VERSION) {
+      throw new StorageError(
+        'version-mismatch',
+        `unit '${MESSAGE_FEEDBACK_UNIT}' medium version ${JSON.stringify(storedVersion)} does not match descriptor version ${MESSAGE_FEEDBACK_VERSION}`,
+      )
+    }
+  }
+}

--- a/apps/dsh-edge/src/http.ts
+++ b/apps/dsh-edge/src/http.ts
@@ -7,6 +7,8 @@ import { EdgeWorkspaceRequestError } from './workspace.ts'
 const textEncoder = new TextEncoder()
 
 export const MAX_SESSION_CREATE_BODY_BYTES = 8_192
+// An 8 KiB feedback note can expand sixfold when JSON escapes control characters.
+export const MAX_MESSAGE_FEEDBACK_BODY_BYTES = 64 * 1_024
 // Four projected image uploads fit after base64 expansion plus the RPC envelope.
 export const MAX_TURN_BODY_BYTES = 10 * 1_024 * 1_024
 export const MAX_WORKSPACE_EXEC_BODY_BYTES = 131_072

--- a/apps/dsh-edge/src/index.ts
+++ b/apps/dsh-edge/src/index.ts
@@ -10,6 +10,7 @@ import {
 } from './auth.ts'
 import {
   EdgeHttpError,
+  MAX_MESSAGE_FEEDBACK_BODY_BYTES,
   MAX_SESSION_CREATE_BODY_BYTES,
   MAX_TURN_BODY_BYTES,
   MAX_WORKSPACE_EXEC_BODY_BYTES,
@@ -166,11 +167,13 @@ async function requestForInstance(request: Request, ownerSessionExpiresAt: numbe
   headers.set(OWNER_SESSION_EXPIRY_HEADER, String(ownerSessionExpiresAt))
   if (request.body === null) return new Request(request, { headers })
   const url = new URL(request.url)
-  const maxBytes = url.pathname.endsWith('/turn')
-    || url.pathname === '/api/session.prompt'
-    || url.pathname === '/api/session.updateQueue'
-    ? MAX_TURN_BODY_BYTES
-    : MAX_SESSION_CREATE_BODY_BYTES
+  const maxBytes = url.pathname === '/api/messageFeedback/put'
+    ? MAX_MESSAGE_FEEDBACK_BODY_BYTES
+    : url.pathname.endsWith('/turn')
+      || url.pathname === '/api/session.prompt'
+      || url.pathname === '/api/session.updateQueue'
+      ? MAX_TURN_BODY_BYTES
+      : MAX_SESSION_CREATE_BODY_BYTES
   const body = await readBoundedBody(
     request,
     maxBytes,

--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -21,6 +21,7 @@ import type {
 import { credentialRef, type CredentialInfo } from '@deepseek-ai/dsh-credentials'
 import LlmRuntime, { ReasoningEffortId, createUserMessage } from '@deepseek-ai/dsh-llm'
 import type { ContentBlock } from '@deepseek-ai/dsh-llm/types'
+import MessageFeedbackService from '@deepseek-ai/dsh-message-feedback'
 import {
   SESSION_SEARCH_RESULT_LIMIT,
   SESSION_SEARCH_SNIPPET_MAX_CODE_POINTS,
@@ -92,6 +93,7 @@ import type { CreateEdgeSessionInput, EdgeSession } from './protocol.ts'
 import { installEdgeWebSearch } from './web-search.ts'
 
 const MAX_TITLE_BYTES = 640
+const MAX_MESSAGE_FEEDBACK_NOTE_BYTES = 8_192
 const MAX_FORK_EVENTS = 8_192
 
 interface EdgeSessionStoreConfig {
@@ -285,6 +287,14 @@ export class EdgeSessionStore {
     await this.context.plugin(AgentRegistry)
     await installEdgeWebSearch(this.context, config.searchBaseURL)
     await this.context.plugin(DurableObjectSessionPersistence, { storage })
+    await this.context.plugin(MessageFeedbackService, {
+      maxNoteBytes: MAX_MESSAGE_FEEDBACK_NOTE_BYTES,
+    })
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+    const { TYPERT: MESSAGE_FEEDBACK_TYPERT } = await import(
+      '@deepseek-ai/dsh-message-feedback/typert' as string
+    )
+    this.context.typert.register(MESSAGE_FEEDBACK_TYPERT as never)
     const workspaceWasInitialized = (await storage.get<{ initialized?: boolean }>(
       'dsh-kv:workspace:__global__',
     ))?.initialized === true

--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -91,6 +91,7 @@ import DurableObjectSessionPersistence, {
 import EdgeModelSelectionBridge from './model-selection-bridge.ts'
 import type { CreateEdgeSessionInput, EdgeSession } from './protocol.ts'
 import { installEdgeWebSearch } from './web-search.ts'
+import { DurableObjectMessageFeedbackStore } from './do-message-feedback-store.ts'
 
 const MAX_TITLE_BYTES = 640
 const MAX_MESSAGE_FEEDBACK_NOTE_BYTES = 8_192
@@ -289,6 +290,7 @@ export class EdgeSessionStore {
     await this.context.plugin(DurableObjectSessionPersistence, { storage })
     await this.context.plugin(MessageFeedbackService, {
       maxNoteBytes: MAX_MESSAGE_FEEDBACK_NOTE_BYTES,
+      store: new DurableObjectMessageFeedbackStore(storage),
     })
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     const { TYPERT: MESSAGE_FEEDBACK_TYPERT } = await import(

--- a/apps/dsh-edge/standalone/expected-boot-graph.json
+++ b/apps/dsh-edge/standalone/expected-boot-graph.json
@@ -226,6 +226,15 @@
     ]
   },
   {
+    "id": "@deepseek-ai/dsh-client-ui-message-feedback",
+    "inject": [
+      "@deepseek-ai/dsh-client-runtime",
+      "@deepseek-ai/dsh-api-remotes",
+      "@deepseek-ai/dsh-client-locale",
+      "@deepseek-ai/dsh-client-ui-conversation"
+    ]
+  },
+  {
     "id": "@deepseek-ai/dsh-client-ui-model-selection",
     "inject": [
       "@deepseek-ai/dsh-client-locale",

--- a/apps/dsh-edge/standalone/package.json
+++ b/apps/dsh-edge/standalone/package.json
@@ -41,6 +41,7 @@
     "@deepseek-ai/dsh-launch-environment": "0.1.1-rc.2",
     "@deepseek-ai/dsh-llm": "0.1.1-rc.2",
     "@deepseek-ai/dsh-llm-deepseek": "0.1.1-rc.2",
+    "@deepseek-ai/dsh-message-feedback": "0.1.1-rc.2",
     "@deepseek-ai/dsh-compaction": "0.1.1-rc.2",
     "@deepseek-ai/dsh-compaction-basic": "0.1.1-rc.2",
     "@deepseek-ai/dsh-compaction-tool-result-pruner": "0.1.1-rc.2",

--- a/apps/dsh-edge/standalone/patches/@deepseek-ai__dsh-message-feedback@0.1.1-rc.2.patch
+++ b/apps/dsh-edge/standalone/patches/@deepseek-ai__dsh-message-feedback@0.1.1-rc.2.patch
@@ -1,0 +1,163 @@
+diff --git a/lib/index.js b/lib/index.js
+index 2a2f0d5b46099b526bfa4fce265ba08ec5742604..16ed38ed05c6d4d77521f16bb2e29c6e184429e5 100644
+--- a/lib/index.js
++++ b/lib/index.js
+@@ -242,9 +242,12 @@ let MessageFeedbackService = (() => {
+ 			"sessions"
+ 		];
+ 		/** Loader validation for the required note-size policy. */
+-		static Config = s.object({ maxNoteBytes: s.number().step(1).min(1).required() });
++		static Config = s.object({
++			maxNoteBytes: s.number().step(1).min(1).required(),
++			store: s.any()
++		});
+ 		maxNoteBytes = __runInitializers(this, _instanceExtraInitializers);
+-		table;
++		store;
+ 		operationTails = /* @__PURE__ */ new Map();
+ 		mutationAdmissionOpen = true;
+ 		/**
+@@ -254,16 +257,25 @@ let MessageFeedbackService = (() => {
+ 		constructor(ctx, config) {
+ 			super(ctx, "messageFeedback");
+ 			this.maxNoteBytes = resolveMaxNoteBytes(config.maxNoteBytes);
++			this.store = config.store;
+ 		}
+-		/** Open and own the one message-feedback sidecar domain. */
++		/** Use an injected point store or open and own the default sidecar domain. */
+ 		async [Service.init]() {
++			if (this.store !== void 0) {
++				this.ctx.effect(() => async () => {
++					this.mutationAdmissionOpen = false;
++					await Promise.all(this.operationTails.values());
++				}, "message-feedback.operations");
++				return;
++			}
+ 			const domain = await this.ctx.storageDomain.open(messageFeedbackDomainSpec);
+ 			this.ctx.effect(() => async () => {
+ 				this.mutationAdmissionOpen = false;
+ 				await Promise.all(this.operationTails.values());
+ 				await domain.close();
+ 			}, "message-feedback.domainClose");
+-			this.table = domain.table("sessions");
++			const table = domain.table("sessions");
++			this.store = { get: (key) => table.get(key), put: (key, value) => table.put(key, value) };
+ 		}
+ 		/**
+ 		* Read feedback belonging to the current persisted Session lifecycle.
+@@ -274,7 +286,7 @@ let MessageFeedbackService = (() => {
+ 		async list(request) {
+ 			const known = await this.inspectSession(request.sessionId);
+ 			if (!known.ok) return known;
+-			const row = this.requireTable().get(request.sessionId);
++			const row = await this.requireStore().get(request.sessionId);
+ 			return success(snapshotList(row !== void 0 && sameIdentity(row, known.value.meta) ? row.items : EMPTY_ITEMS));
+ 		}
+ 		/**
+@@ -301,8 +313,8 @@ let MessageFeedbackService = (() => {
+ 					sessionId: request.sessionId,
+ 					messageId: request.messageId
+ 				});
+-				const table = this.requireTable();
+-				const stored = table.get(request.sessionId);
++				const store = this.requireStore();
++				const stored = await store.get(request.sessionId);
+ 				const items = (stored !== void 0 && sameIdentity(stored, durable.meta) ? stored : void 0)?.items ?? EMPTY_ITEMS;
+ 				const index = items.findIndex((item) => item.messageId === request.messageId);
+ 				const existing = items[index];
+@@ -320,7 +332,7 @@ let MessageFeedbackService = (() => {
+ 				const nextItems = [...items];
+ 				if (index === -1) nextItems.push(item);
+ 				else nextItems[index] = item;
+-				await table.put(request.sessionId, rowSnapshot(identityOf(durable.meta), nextItems));
++				await store.put(request.sessionId, rowSnapshot(identityOf(durable.meta), nextItems));
+ 				return success(snapshotItem(item));
+ 			});
+ 		}
+@@ -334,13 +346,13 @@ let MessageFeedbackService = (() => {
+ 			return this.enqueue(request.sessionId, async () => {
+ 				const known = await this.inspectSession(request.sessionId);
+ 				if (!known.ok) return known;
+-				const table = this.requireTable();
+-				const stored = table.get(request.sessionId);
++				const store = this.requireStore();
++				const stored = await store.get(request.sessionId);
+ 				const items = (stored !== void 0 && sameIdentity(stored, known.value.meta) ? stored : void 0)?.items ?? EMPTY_ITEMS;
+ 				const existing = items.find((item) => item.messageId === request.messageId);
+ 				if (existing === void 0) return success(Object.freeze({ absent: true }));
+ 				if (request.ifVersion !== existing.version) return rejected(this.versionConflict(existing));
+-				await table.put(request.sessionId, rowSnapshot(identityOf(known.value.meta), items.filter((item) => item !== existing)));
++				await store.put(request.sessionId, rowSnapshot(identityOf(known.value.meta), items.filter((item) => item !== existing)));
+ 				return success(Object.freeze({ absent: true }));
+ 			});
+ 		}
+@@ -409,10 +421,10 @@ let MessageFeedbackService = (() => {
+ 				if (this.operationTails.get(sessionId) === tail) this.operationTails.delete(sessionId);
+ 			});
+ 		}
+-		/** Resolve the initialized durable table or fail a broken service lifecycle. */
+-		requireTable() {
+-			if (this.table === void 0) throw new Error("message-feedback: durable domain is not initialized");
+-			return this.table;
++		/** Resolve the initialized durable store or fail a broken service lifecycle. */
++		requireStore() {
++			if (this.store === void 0) throw new Error("message-feedback: durable store is not initialized");
++			return this.store;
+ 		}
+ 	};
+ })();
+diff --git a/lib/types/index.d.ts b/lib/types/index.d.ts
+index d5dd7ae022c7ad18b6e11b19ffd006bdd50d77b2..34a31b5a9b9ef3df291f712b4b9423ae6ee2a8a5 100644
+--- a/lib/types/index.d.ts
++++ b/lib/types/index.d.ts
+@@ -6,13 +6,21 @@ import { Context, Service } from '@deepseek-ai/cordis';
+ import s from '@deepseek-ai/schemastery';
+ import { TypertRemoteService } from '@deepseek-ai/dsh-typert-protocol';
+ import type { MessageFeedbackDeleteRequest, MessageFeedbackDeleteResult, MessageFeedbackListRequest, MessageFeedbackListResult, MessageFeedbackPutRequest, MessageFeedbackPutResult } from './types.ts';
++import type { MessageFeedbackRow } from './spec.ts';
+ export type * from './types.ts';
+ export { messageFeedbackDomainSpec, messageFeedbackItemSchema, messageFeedbackRatingSchema, messageFeedbackRowSchema, messageFeedbackSessionIdentitySchema, messageFeedbackVersionSchema, } from './spec.ts';
+ export type { MessageFeedbackRow, MessageFeedbackSessionIdentity } from './spec.ts';
++/** Deployment-owned persistence seam for one feedback row per Session. */
++export interface MessageFeedbackStore {
++    get(sessionId: string): MessageFeedbackRow | undefined | Promise<MessageFeedbackRow | undefined>;
++    put(sessionId: string, row: MessageFeedbackRow): void | Promise<void>;
++}
+ /** Required deployment policy for optional notes. */
+ export interface Config {
+     /** Maximum UTF-8 byte length accepted for one note. */
+     readonly maxNoteBytes: number;
++    /** Optional point-read store; storage-domain remains the default. */
++    readonly store?: MessageFeedbackStore;
+ }
+ declare module '@deepseek-ai/cordis' {
+     interface Context {
+@@ -28,7 +36,7 @@ export declare class MessageFeedbackService extends TypertRemoteService {
+     /** Loader validation for the required note-size policy. */
+     static Config: s<Config>;
+     private readonly maxNoteBytes;
+-    private table?;
++    private store?;
+     private readonly operationTails;
+     private mutationAdmissionOpen;
+     /**
+@@ -36,7 +44,7 @@ export declare class MessageFeedbackService extends TypertRemoteService {
+      * @param config - Required note-size policy.
+      */
+     constructor(ctx: Context, config: Config);
+-    /** Open and own the one message-feedback sidecar domain. */
++    /** Use an injected point store or open and own the default sidecar domain. */
+     protected [Service.init](): Promise<void>;
+     /**
+      * Read feedback belonging to the current persisted Session lifecycle.
+@@ -81,8 +89,8 @@ export declare class MessageFeedbackService extends TypertRemoteService {
+     private versionConflict;
+     /** Queue a complete read/compare/write mutation behind this Session's prior mutation. */
+     private enqueue;
+-    /** Resolve the initialized durable table or fail a broken service lifecycle. */
+-    private requireTable;
++    /** Resolve the initialized durable store or fail a broken service lifecycle. */
++    private requireStore;
+ }
+ export default MessageFeedbackService;
+ //# sourceMappingURL=index.d.ts.map

--- a/apps/dsh-edge/standalone/patches/audit.json
+++ b/apps/dsh-edge/standalone/patches/audit.json
@@ -10,6 +10,11 @@
     "removeWhen": "The published plugin's apply() forwards resolveFiles from the plugin config to the adapter constructor."
   },
   {
+    "package": "@deepseek-ai/dsh-message-feedback",
+    "rationale": "Inject an Edge-owned point-read feedback store so Durable Object startup does not materialize every retained feedback row through storage-domain loadAll().",
+    "removeWhen": "The published message-feedback service accepts an equivalent bounded point-read store or no longer loads the complete feedback domain during initialization."
+  },
+  {
     "package": "@deepseek-ai/dsh-session-persistence",
     "rationale": "Expose bounded validated reads and failed-first-write abandonment required by the Durable Object persistence adapter.",
     "removeWhen": "The published persistence coordinator provides equivalent bounded-page validation and unmaterialized-session abandonment APIs, and the Edge persistence suite passes without this patch."

--- a/apps/dsh-edge/standalone/pnpm-lock.yaml
+++ b/apps/dsh-edge/standalone/pnpm-lock.yaml
@@ -10,6 +10,7 @@ patchedDependencies:
   '@deepseek-ai/dsh-api-gateway@0.1.1-rc.2': c27c92b0642941349a7b8b2144fb0e300c903ae8250775ca4de4638a515f468d
   '@deepseek-ai/dsh-llm-deepseek@0.1.1-rc.2': cb1b831ea1c82f52e4f4e859056561ba1f60e148a4fdd60e65fbcf5824e50a21
   '@deepseek-ai/dsh-llm@0.1.1-rc.2': 1837c37e725fba94ea746dffef5bc6687e19c8446533e71d53de7b2b064e0a84
+  '@deepseek-ai/dsh-message-feedback@0.1.1-rc.2': 51f6c4d04d8910893392fcf547177fcf6160fa21370bb0e478da514260edb182
   '@deepseek-ai/dsh-sandbox@0.1.1-rc.2': 5c8f9d5681d2b3512831cf8ac5ad7c8e4c332f63c41fcc57988fc191666c81a5
   '@deepseek-ai/dsh-session-persistence@0.1.1-rc.2': ae9f4b486992d7dd8c625f24562b589c483d14b5f5b56d71855df0a44450a149
   '@deepseek-ai/dsh-web-search-deepseek@0.1.1-rc.2': eb7c0136d390f3ab6b70c282de0bfc15d9f483ea9558c3fdc4c85b657146ca87
@@ -51,7 +52,7 @@ importers:
         version: 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-client-ui-settings-models':
         specifier: 0.1.1-rc.2
-        version: 0.1.1-rc.2(33525ddd944b6927341465595f9f599b)
+        version: 0.1.1-rc.2(572ddfae9597567a120c986260f493f8)
       '@deepseek-ai/dsh-compaction':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(b6e3ebe59a56ce5c479ddf7e07d6ea8a)
@@ -75,7 +76,7 @@ importers:
         version: 0.1.1-rc.2(96f94b0b90aa520c6f6eaef05e86c447)
       '@deepseek-ai/dsh-host-apiproxy':
         specifier: 0.1.1-rc.2
-        version: 0.1.1-rc.2(05a0d570a71115c0b1f1440c687a75cc)
+        version: 0.1.1-rc.2(360d1ebf0d3396cdfcf1a4f4a107a92e)
       '@deepseek-ai/dsh-host-webserver':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
@@ -93,7 +94,7 @@ importers:
         version: 0.1.1-rc.2(patch_hash=cb1b831ea1c82f52e4f4e859056561ba1f60e148a4fdd60e65fbcf5824e50a21)(3253d8bc1d8c30bbca52f480e02637f2)
       '@deepseek-ai/dsh-message-feedback':
         specifier: 0.1.1-rc.2
-        version: 0.1.1-rc.2(619e8897574909434c2c18a5adadde17)
+        version: 0.1.1-rc.2(patch_hash=51f6c4d04d8910893392fcf547177fcf6160fa21370bb0e478da514260edb182)(619e8897574909434c2c18a5adadde17)
       '@deepseek-ai/dsh-output-retention':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
@@ -4933,7 +4934,7 @@ snapshots:
       '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-typert-registry': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)':
+  '@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f)
@@ -4947,7 +4948,7 @@ snapshots:
       '@deepseek-ai/dsh-host-plugin-inventory': 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.1-rc.2(patch_hash=1837c37e725fba94ea746dffef5bc6687e19c8446533e71d53de7b2b064e0a84)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-message-feedback': 0.1.1-rc.2(619e8897574909434c2c18a5adadde17)
+      '@deepseek-ai/dsh-message-feedback': 0.1.1-rc.2(patch_hash=51f6c4d04d8910893392fcf547177fcf6160fa21370bb0e478da514260edb182)(619e8897574909434c2c18a5adadde17)
       '@deepseek-ai/dsh-session': 0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8)
       '@deepseek-ai/dsh-session-persistence': 0.1.1-rc.2(patch_hash=ae9f4b486992d7dd8c625f24562b589c483d14b5f5b56d71855df0a44450a149)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-session-reference': 0.1.1-rc.2(0a2211595c200a2c74dc8c02efabef61)
@@ -5150,7 +5151,7 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-commands': 0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a)
-      '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.2(05a0d570a71115c0b1f1440c687a75cc)
+      '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.2(360d1ebf0d3396cdfcf1a4f4a107a92e)
       '@deepseek-ai/dsh-host-webserver': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.1-rc.2(patch_hash=1837c37e725fba94ea746dffef5bc6687e19c8446533e71d53de7b2b064e0a84)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
@@ -5171,13 +5172,13 @@ snapshots:
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)':
+  '@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
@@ -5189,15 +5190,15 @@ snapshots:
       '@deepseek-ai/dsh-host-webserver': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)':
+  '@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
       '@deepseek-ai/dsh-commands': 0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a)
-      '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.2(05a0d570a71115c0b1f1440c687a75cc)
+      '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.2(360d1ebf0d3396cdfcf1a4f4a107a92e)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.1-rc.2(patch_hash=1837c37e725fba94ea746dffef5bc6687e19c8446533e71d53de7b2b064e0a84)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-llm-retry': 0.1.1-rc.2(d324c4f062c2281f5d775317220bb9ca)
@@ -5213,59 +5214,59 @@ snapshots:
       - '@types/react'
       - react
 
-  '@deepseek-ai/dsh-client-ui-agent-preset@0.1.1-rc.2(0c526827c49d5a6939284fde1b0d5355)':
+  '@deepseek-ai/dsh-client-ui-agent-preset@0.1.1-rc.2(34c563929ac3dc27cefb1af3642b0d7d)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-brand-official@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-brand-official@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
-      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-commands@0.1.1-rc.2(0dcaae0e43e29a521d47eb5c34c4d7cf)':
+  '@deepseek-ai/dsh-client-ui-commands@0.1.1-rc.2(2d03147ded37009831af4be2d9a49a0d)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-commands': 0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)':
+  '@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-layout': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-layout': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-commands': 0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a)
       '@deepseek-ai/dsh-compaction': 0.1.1-rc.2(b6e3ebe59a56ce5c479ddf7e07d6ea8a)
       '@deepseek-ai/dsh-goal': 0.1.1-rc.2(6da1c6164f4e2ed0a24356115c892adc)
@@ -5281,268 +5282,268 @@ snapshots:
       '@deepseek-ai/schemastery': 3.18.1
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-cordis@0.1.1-rc.2(3e628ee5debd5a8633832fc7fbfe8208)':
+  '@deepseek-ai/dsh-client-ui-cordis@0.1.1-rc.2(03c16a21947876dd20bd6e8c19daaf85)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-tool': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-cordis-client-runner': 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-modules@0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-tool': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-cordis-client-runner': 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-modules@0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-deliverables@0.1.1-rc.2(99aeb1e1035e20474806fbb5bf47739d)':
+  '@deepseek-ai/dsh-client-ui-deliverables@0.1.1-rc.2(7e9c0fc88e5d84ee13b1974257bb2ba3)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-system-prompt': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-llm@0.1.1-rc.2(patch_hash=1837c37e725fba94ea746dffef5bc6687e19c8446533e71d53de7b2b064e0a84)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-scope@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
 
-  '@deepseek-ai/dsh-client-ui-directory-picker-browse@0.1.1-rc.2(0c821d80d23bb566dfade7d393f31954)':
+  '@deepseek-ai/dsh-client-ui-directory-picker-browse@0.1.1-rc.2(e1f4667761be9f927831bd66e862fff6)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-directory-picker-native@0.1.1-rc.2(da26fe8b66271d0d484eb5759ba7df50)':
+  '@deepseek-ai/dsh-client-ui-directory-picker-native@0.1.1-rc.2(4fabe46ad6ef4a4db6f76bd21c9b10be)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-goal@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-commands@0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a))(@deepseek-ai/dsh-goal@0.1.1-rc.2(6da1c6164f4e2ed0a24356115c892adc))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-client-ui-goal@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-commands@0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a))(@deepseek-ai/dsh-goal@0.1.1-rc.2(6da1c6164f4e2ed0a24356115c892adc))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
       '@deepseek-ai/dsh-commands': 0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a)
       '@deepseek-ai/dsh-goal': 0.1.1-rc.2(6da1c6164f4e2ed0a24356115c892adc)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-session': 0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8)
       '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-client-ui-input-trigger@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-input-trigger@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
       '@deepseek-ai/dsh-file-reference': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-jobs@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-jobs@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-theme': 0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-theme': 0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-message-feedback@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-message-feedback@0.1.1-rc.2(619e8897574909434c2c18a5adadde17))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))':
+  '@deepseek-ai/dsh-client-ui-message-feedback@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-message-feedback@0.1.1-rc.2(patch_hash=51f6c4d04d8910893392fcf547177fcf6160fa21370bb0e478da514260edb182)(619e8897574909434c2c18a5adadde17))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-message-feedback': 0.1.1-rc.2(619e8897574909434c2c18a5adadde17)
+      '@deepseek-ai/dsh-message-feedback': 0.1.1-rc.2(patch_hash=51f6c4d04d8910893392fcf547177fcf6160fa21370bb0e478da514260edb182)(619e8897574909434c2c18a5adadde17)
       '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-client-ui-model-selection@0.1.1-rc.2(64ad664935ee122638ae5ad59562bd38)':
+  '@deepseek-ai/dsh-client-ui-model-selection@0.1.1-rc.2(15f10b45159031ea6491bd76057d8b68)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.2(0dcaae0e43e29a521d47eb5c34c4d7cf)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.2(2d03147ded37009831af4be2d9a49a0d)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-permission-presets@0.1.1-rc.2(9c8cb055e4906248e1c42c2b94c3c542)':
+  '@deepseek-ai/dsh-client-ui-permission-presets@0.1.1-rc.2(bd57790e3a4dda6d6827cc4b0dbfd3ff)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.2(0dcaae0e43e29a521d47eb5c34c4d7cf)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.2(2d03147ded37009831af4be2d9a49a0d)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-permission-presets': 0.1.1-rc.2(798027f17c80d1d76904031a2ed668f2)
 
-  '@deepseek-ai/dsh-client-ui-plan@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-plan-mode@0.1.1-rc.2(2f5635e3470fbbfcb2e366be42460c9b))':
+  '@deepseek-ai/dsh-client-ui-plan@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-plan-mode@0.1.1-rc.2(2f5635e3470fbbfcb2e366be42460c9b))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-plan-mode': 0.1.1-rc.2(2f5635e3470fbbfcb2e366be42460c9b)
 
-  '@deepseek-ai/dsh-client-ui-reference@0.1.1-rc.2(4b8221547eb644ce04de86556a101edf)':
+  '@deepseek-ai/dsh-client-ui-reference@0.1.1-rc.2(1300e2421a240e6bcae411d87d17d11e)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-file-reference': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-session-reference': 0.1.1-rc.2(0a2211595c200a2c74dc8c02efabef61)
       '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-client-ui-renderer@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(react@18.3.1)':
+  '@deepseek-ai/dsh-client-ui-renderer@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(react@18.3.1)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       use-sync-external-store: 1.2.0(react@18.3.1)
     transitivePeerDependencies:
       - react
 
-  '@deepseek-ai/dsh-client-ui-settings-general@0.1.1-rc.2(be47fd1725bce088fc90f77991d4d26f)':
+  '@deepseek-ai/dsh-client-ui-settings-general@0.1.1-rc.2(01142328854a8ebb4431b0b6ef11a34f)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
-      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-settings-models@0.1.1-rc.2(33525ddd944b6927341465595f9f599b)':
+  '@deepseek-ai/dsh-client-ui-settings-models@0.1.1-rc.2(572ddfae9597567a120c986260f493f8)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  ? '@deepseek-ai/dsh-client-ui-settings-plugin-inventory@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))'
+  ? '@deepseek-ai/dsh-client-ui-settings-plugin-inventory@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))'
   : dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-settings-plugins@0.1.1-rc.2(33525ddd944b6927341465595f9f599b)':
+  '@deepseek-ai/dsh-client-ui-settings-plugins@0.1.1-rc.2(572ddfae9597567a120c986260f493f8)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))':
+  '@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-layout': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-layout': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-skill@0.1.1-rc.2(2cd8574d5023d21cac86708c5f2ca42e)':
+  '@deepseek-ai/dsh-client-ui-skill@0.1.1-rc.2(aa8275c181b83fe92c1e0c493bbc9cc9)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-tool': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-tool': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-client-ui-subagent@0.1.1-rc.2(60b858e23276ef4755d354b300a5db4a)':
+  '@deepseek-ai/dsh-client-ui-subagent@0.1.1-rc.2(7a6f173a45295102ff57e0f3d4d6d2eb)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-subagent': 0.1.1-rc.2(7665274f1823f01471db7d84a0534907)
       '@deepseek-ai/dsh-token-meter': 0.1.1-rc.2(65ea61bcb4cac1bce6bb9938c9eb63bb)
 
-  '@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957)':
+  '@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-host-webserver': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-tool@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-tool@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-trajectory@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-compaction@0.1.1-rc.2(b6e3ebe59a56ce5c479ddf7e07d6ea8a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-tools@0.1.1-rc.2(2c8e378720861603b19282aa9c632379))(react-dom@19.2.8(react@18.3.1))(react@18.3.1)':
+  '@deepseek-ai/dsh-client-ui-trajectory@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-compaction@0.1.1-rc.2(b6e3ebe59a56ce5c479ddf7e07d6ea8a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-tools@0.1.1-rc.2(2c8e378720861603b19282aa9c632379))(react-dom@19.2.8(react@18.3.1))(react@18.3.1)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
       '@deepseek-ai/dsh-compaction': 0.1.1-rc.2(b6e3ebe59a56ce5c479ddf7e07d6ea8a)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-tools': 0.1.1-rc.2(2c8e378720861603b19282aa9c632379)
@@ -5552,35 +5553,35 @@ snapshots:
       - react
       - react-dom
 
-  '@deepseek-ai/dsh-client-ui-user-questions@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-user-questions@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
-  '@deepseek-ai/dsh-client-ui-workflow-run@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8))(@deepseek-ai/dsh-tool-workflow@0.1.1-rc.2(b795060d5531e2fef190e9e81c268208))(@deepseek-ai/dsh-workflow@0.1.1-rc.2(67e2450d9d139f750d3b2ea7d3c36e10))':
+  '@deepseek-ai/dsh-client-ui-workflow-run@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8))(@deepseek-ai/dsh-tool-workflow@0.1.1-rc.2(b795060d5531e2fef190e9e81c268208))(@deepseek-ai/dsh-workflow@0.1.1-rc.2(67e2450d9d139f750d3b2ea7d3c36e10))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-session': 0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8)
       '@deepseek-ai/dsh-tool-workflow': 0.1.1-rc.2(b795060d5531e2fef190e9e81c268208)
       '@deepseek-ai/dsh-workflow': 0.1.1-rc.2(67e2450d9d139f750d3b2ea7d3c36e10)
 
-  '@deepseek-ai/dsh-client-ui-workspace@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-client-ui-workspace@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
-      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       clsx: 2.1.1
 
@@ -5674,15 +5675,15 @@ snapshots:
       '@deepseek-ai/dsh-llm': 0.1.1-rc.2(patch_hash=1837c37e725fba94ea746dffef5bc6687e19c8446533e71d53de7b2b064e0a84)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-session': 0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8)
 
-  '@deepseek-ai/dsh-cordis-client-runner@0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-modules@0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-cordis-client-runner@0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-modules@0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
       '@deepseek-ai/dsh-client-modules': 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-theme': 0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-theme': 0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
   '@deepseek-ai/dsh-cordis-host-runner@0.1.1-rc.2(5b876fcaf2fb26aaa4c7bb2b465fe154)':
@@ -5794,13 +5795,13 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-host-apiproxy@0.1.1-rc.2(05a0d570a71115c0b1f1440c687a75cc)':
+  '@deepseek-ai/dsh-host-apiproxy@0.1.1-rc.2(360d1ebf0d3396cdfcf1a4f4a107a92e)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f)
       '@deepseek-ai/dsh-agent-default-model': 0.1.1-rc.2(cb2f1581451b2fa42233c9a627f51ae3)
       '@deepseek-ai/dsh-agent-presets': 0.1.1-rc.2(d9f3616961e6351fcb70538e475fb6a0)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-commands': 0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a)
@@ -5845,12 +5846,12 @@ snapshots:
       - '@deepseek-ai/dsh-typert-protocol'
       - '@deepseek-ai/dsh-typert-registry'
 
-  '@deepseek-ai/dsh-host-directory-picker-auto@0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-ui-directory-picker-browse@0.1.1-rc.2(0c821d80d23bb566dfade7d393f31954))(@deepseek-ai/dsh-client-ui-directory-picker-native@0.1.1-rc.2(da26fe8b66271d0d484eb5759ba7df50))(@deepseek-ai/dsh-host-directory-picker-browse@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-directory-picker-native@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-host-directory-picker-auto@0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-ui-directory-picker-browse@0.1.1-rc.2(e1f4667761be9f927831bd66e862fff6))(@deepseek-ai/dsh-client-ui-directory-picker-native@0.1.1-rc.2(4fabe46ad6ef4a4db6f76bd21c9b10be))(@deepseek-ai/dsh-host-directory-picker-browse@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-directory-picker-native@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)
-      '@deepseek-ai/dsh-client-ui-directory-picker-browse': 0.1.1-rc.2(0c821d80d23bb566dfade7d393f31954)
-      '@deepseek-ai/dsh-client-ui-directory-picker-native': 0.1.1-rc.2(da26fe8b66271d0d484eb5759ba7df50)
+      '@deepseek-ai/dsh-client-ui-directory-picker-browse': 0.1.1-rc.2(e1f4667761be9f927831bd66e862fff6)
+      '@deepseek-ai/dsh-client-ui-directory-picker-native': 0.1.1-rc.2(4fabe46ad6ef4a4db6f76bd21c9b10be)
       '@deepseek-ai/dsh-host-directory-picker-browse': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-host-directory-picker-native': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-host-webserver': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
@@ -5984,7 +5985,7 @@ snapshots:
       '@deepseek-ai/dsh-timeout': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-message-feedback@0.1.1-rc.2(619e8897574909434c2c18a5adadde17)':
+  '@deepseek-ai/dsh-message-feedback@0.1.1-rc.2(patch_hash=51f6c4d04d8910893392fcf547177fcf6160fa21370bb0e478da514260edb182)(619e8897574909434c2c18a5adadde17)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
@@ -6113,13 +6114,13 @@ snapshots:
       '@deepseek-ai/dsh-session-persistence': 0.1.1-rc.2(patch_hash=ae9f4b486992d7dd8c625f24562b589c483d14b5f5b56d71855df0a44450a149)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-tools': 0.1.1-rc.2(2c8e378720861603b19282aa9c632379)
 
-  '@deepseek-ai/dsh-session-log-export@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-commands@0.1.1-rc.2(0dcaae0e43e29a521d47eb5c34c4d7cf))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-commands@0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
+  '@deepseek-ai/dsh-session-log-export@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-commands@0.1.1-rc.2(2d03147ded37009831af4be2d9a49a0d))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-commands@0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.2(0dcaae0e43e29a521d47eb5c34c4d7cf)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.2(2d03147ded37009831af4be2d9a49a0d)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
       '@deepseek-ai/dsh-commands': 0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
@@ -6711,54 +6712,54 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/cordis-plugin-loader': 1.0.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-agent-presets': 0.1.1-rc.2(d9f3616961e6351fcb70538e475fb6a0)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-app-boot': 0.1.1-rc.2(91ece971a58887326f35fa7d9d583cd5)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
       '@deepseek-ai/dsh-client-hmr': 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-modules@0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab)
+      '@deepseek-ai/dsh-client-locale': 0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e)
       '@deepseek-ai/dsh-client-modules': 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd)
-      '@deepseek-ai/dsh-client-ui-agent-preset': 0.1.1-rc.2(0c526827c49d5a6939284fde1b0d5355)
-      '@deepseek-ai/dsh-client-ui-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-brand-official': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.2(0dcaae0e43e29a521d47eb5c34c4d7cf)
-      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189)
-      '@deepseek-ai/dsh-client-ui-cordis': 0.1.1-rc.2(3e628ee5debd5a8633832fc7fbfe8208)
-      '@deepseek-ai/dsh-client-ui-deliverables': 0.1.1-rc.2(99aeb1e1035e20474806fbb5bf47739d)
-      '@deepseek-ai/dsh-client-ui-directory-picker-browse': 0.1.1-rc.2(0c821d80d23bb566dfade7d393f31954)
-      '@deepseek-ai/dsh-client-ui-directory-picker-native': 0.1.1-rc.2(da26fe8b66271d0d484eb5759ba7df50)
-      '@deepseek-ai/dsh-client-ui-goal': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-commands@0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a))(@deepseek-ai/dsh-goal@0.1.1-rc.2(6da1c6164f4e2ed0a24356115c892adc))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-jobs': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-layout': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-message-feedback': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-message-feedback@0.1.1-rc.2(619e8897574909434c2c18a5adadde17))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-client-ui-model-selection': 0.1.1-rc.2(64ad664935ee122638ae5ad59562bd38)
-      '@deepseek-ai/dsh-client-ui-permission-presets': 0.1.1-rc.2(9c8cb055e4906248e1c42c2b94c3c542)
-      '@deepseek-ai/dsh-client-ui-plan': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-plan-mode@0.1.1-rc.2(2f5635e3470fbbfcb2e366be42460c9b))
-      '@deepseek-ai/dsh-client-ui-reference': 0.1.1-rc.2(4b8221547eb644ce04de86556a101edf)
-      '@deepseek-ai/dsh-client-ui-renderer': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(react@18.3.1)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
-      '@deepseek-ai/dsh-client-ui-settings-general': 0.1.1-rc.2(be47fd1725bce088fc90f77991d4d26f)
-      '@deepseek-ai/dsh-client-ui-settings-models': 0.1.1-rc.2(33525ddd944b6927341465595f9f599b)
-      '@deepseek-ai/dsh-client-ui-settings-plugin-inventory': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-settings-plugins': 0.1.1-rc.2(33525ddd944b6927341465595f9f599b)
-      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-skill': 0.1.1-rc.2(2cd8574d5023d21cac86708c5f2ca42e)
-      '@deepseek-ai/dsh-client-ui-subagent': 0.1.1-rc.2(60b858e23276ef4755d354b300a5db4a)
-      '@deepseek-ai/dsh-client-ui-theme': 0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957)
-      '@deepseek-ai/dsh-client-ui-tool': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-trajectory': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-compaction@0.1.1-rc.2(b6e3ebe59a56ce5c479ddf7e07d6ea8a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-tools@0.1.1-rc.2(2c8e378720861603b19282aa9c632379))(react-dom@19.2.8(react@18.3.1))(react@18.3.1)
-      '@deepseek-ai/dsh-client-ui-user-questions': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-client-ui-workflow-run': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8))(@deepseek-ai/dsh-tool-workflow@0.1.1-rc.2(b795060d5531e2fef190e9e81c268208))(@deepseek-ai/dsh-workflow@0.1.1-rc.2(67e2450d9d139f750d3b2ea7d3c36e10))
-      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93)
+      '@deepseek-ai/dsh-client-ui-agent-preset': 0.1.1-rc.2(34c563929ac3dc27cefb1af3642b0d7d)
+      '@deepseek-ai/dsh-client-ui-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-brand-official': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-commands': 0.1.1-rc.2(2d03147ded37009831af4be2d9a49a0d)
+      '@deepseek-ai/dsh-client-ui-conversation': 0.1.1-rc.2(428fee435ea43683f09867406d5417ac)
+      '@deepseek-ai/dsh-client-ui-cordis': 0.1.1-rc.2(03c16a21947876dd20bd6e8c19daaf85)
+      '@deepseek-ai/dsh-client-ui-deliverables': 0.1.1-rc.2(7e9c0fc88e5d84ee13b1974257bb2ba3)
+      '@deepseek-ai/dsh-client-ui-directory-picker-browse': 0.1.1-rc.2(e1f4667761be9f927831bd66e862fff6)
+      '@deepseek-ai/dsh-client-ui-directory-picker-native': 0.1.1-rc.2(4fabe46ad6ef4a4db6f76bd21c9b10be)
+      '@deepseek-ai/dsh-client-ui-goal': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-commands@0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a))(@deepseek-ai/dsh-goal@0.1.1-rc.2(6da1c6164f4e2ed0a24356115c892adc))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-client-ui-input-trigger': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-file-reference@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-jobs': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-layout': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-message-feedback': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-message-feedback@0.1.1-rc.2(patch_hash=51f6c4d04d8910893392fcf547177fcf6160fa21370bb0e478da514260edb182)(619e8897574909434c2c18a5adadde17))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
+      '@deepseek-ai/dsh-client-ui-model-selection': 0.1.1-rc.2(15f10b45159031ea6491bd76057d8b68)
+      '@deepseek-ai/dsh-client-ui-permission-presets': 0.1.1-rc.2(bd57790e3a4dda6d6827cc4b0dbfd3ff)
+      '@deepseek-ai/dsh-client-ui-plan': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-plan-mode@0.1.1-rc.2(2f5635e3470fbbfcb2e366be42460c9b))
+      '@deepseek-ai/dsh-client-ui-reference': 0.1.1-rc.2(1300e2421a240e6bcae411d87d17d11e)
+      '@deepseek-ai/dsh-client-ui-renderer': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(react@18.3.1)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-ui-settings-general': 0.1.1-rc.2(01142328854a8ebb4431b0b6ef11a34f)
+      '@deepseek-ai/dsh-client-ui-settings-models': 0.1.1-rc.2(572ddfae9597567a120c986260f493f8)
+      '@deepseek-ai/dsh-client-ui-settings-plugin-inventory': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-settings-plugins': 0.1.1-rc.2(572ddfae9597567a120c986260f493f8)
+      '@deepseek-ai/dsh-client-ui-sidebar': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-skill': 0.1.1-rc.2(aa8275c181b83fe92c1e0c493bbc9cc9)
+      '@deepseek-ai/dsh-client-ui-subagent': 0.1.1-rc.2(7a6f173a45295102ff57e0f3d4d6d2eb)
+      '@deepseek-ai/dsh-client-ui-theme': 0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a)
+      '@deepseek-ai/dsh-client-ui-tool': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-trajectory': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-compaction@0.1.1-rc.2(b6e3ebe59a56ce5c479ddf7e07d6ea8a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-tools@0.1.1-rc.2(2c8e378720861603b19282aa9c632379))(react-dom@19.2.8(react@18.3.1))(react@18.3.1)
+      '@deepseek-ai/dsh-client-ui-user-questions': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-client-ui-workflow-run': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8))(@deepseek-ai/dsh-tool-workflow@0.1.1-rc.2(b795060d5531e2fef190e9e81c268208))(@deepseek-ai/dsh-workflow@0.1.1-rc.2(67e2450d9d139f750d3b2ea7d3c36e10))
+      '@deepseek-ai/dsh-client-ui-workspace': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-client-ui-sidebar@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-layout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-cmdline': 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-code-runtime-worker-thread': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-code-runtime@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-cordis-client-runner': 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-modules@0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(7f7ecc83f29d95f2109842c7e2921957))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-cordis-client-runner': 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-modules@0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-theme@0.1.1-rc.2(1dc42eb8aa52118969ab6111f63a538a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-cordis-host-runner': 0.1.1-rc.2(5b876fcaf2fb26aaa4c7bb2b465fe154)
       '@deepseek-ai/dsh-file-reference': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-agent@0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-file-reference-local': 0.1.1-rc.2(8819751160f69901fe487a71c1df9334)
-      '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.2(05a0d570a71115c0b1f1440c687a75cc)
-      '@deepseek-ai/dsh-host-directory-picker-auto': 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-ui-directory-picker-browse@0.1.1-rc.2(0c821d80d23bb566dfade7d393f31954))(@deepseek-ai/dsh-client-ui-directory-picker-native@0.1.1-rc.2(da26fe8b66271d0d484eb5759ba7df50))(@deepseek-ai/dsh-host-directory-picker-browse@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-directory-picker-native@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.2(360d1ebf0d3396cdfcf1a4f4a107a92e)
+      '@deepseek-ai/dsh-host-directory-picker-auto': 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-ui-directory-picker-browse@0.1.1-rc.2(e1f4667761be9f927831bd66e862fff6))(@deepseek-ai/dsh-client-ui-directory-picker-native@0.1.1-rc.2(4fabe46ad6ef4a4db6f76bd21c9b10be))(@deepseek-ai/dsh-host-directory-picker-browse@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-directory-picker-native@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-host-directory-picker-browse': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-host-directory-picker-native': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-host-frontend-static': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-host-webserver@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
@@ -6766,8 +6767,8 @@ snapshots:
       '@deepseek-ai/dsh-host-webserver': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-launch-environment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-message-feedback': 0.1.1-rc.2(619e8897574909434c2c18a5adadde17)
-      '@deepseek-ai/dsh-session-log-export': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(9f64d0e0e93bd8c1b0fb8d157ebc3dab))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(67b81c1a3514b22cfbcb0032735b0ecd))(@deepseek-ai/dsh-client-ui-commands@0.1.1-rc.2(0dcaae0e43e29a521d47eb5c34c4d7cf))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(032a1edfcb409f70b4ad3bdc02fb2189))(@deepseek-ai/dsh-commands@0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
+      '@deepseek-ai/dsh-message-feedback': 0.1.1-rc.2(patch_hash=51f6c4d04d8910893392fcf547177fcf6160fa21370bb0e478da514260edb182)(619e8897574909434c2c18a5adadde17)
+      '@deepseek-ai/dsh-session-log-export': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-locale@0.1.1-rc.2(365e05db218ebe54af61b54e6d13873e))(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(25dcda2a1b777fb1b2cfcba7679e4d93))(@deepseek-ai/dsh-client-ui-commands@0.1.1-rc.2(2d03147ded37009831af4be2d9a49a0d))(@deepseek-ai/dsh-client-ui-conversation@0.1.1-rc.2(428fee435ea43683f09867406d5417ac))(@deepseek-ai/dsh-commands@0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-session-projection-cache': 0.1.1-rc.2(3aa7aa16acb25d2dd97a057835771970)
       '@deepseek-ai/dsh-session-reference': 0.1.1-rc.2(0a2211595c200a2c74dc8c02efabef61)
       '@deepseek-ai/dsh-session-stats': 0.1.1-rc.2(2cc1c3b85915b5db22e89ab20e8540de)

--- a/apps/dsh-edge/standalone/pnpm-lock.yaml
+++ b/apps/dsh-edge/standalone/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
       '@deepseek-ai/dsh-llm-deepseek':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(patch_hash=cb1b831ea1c82f52e4f4e859056561ba1f60e148a4fdd60e65fbcf5824e50a21)(3253d8bc1d8c30bbca52f480e02637f2)
+      '@deepseek-ai/dsh-message-feedback':
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(619e8897574909434c2c18a5adadde17)
       '@deepseek-ai/dsh-output-retention':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))

--- a/apps/dsh-edge/standalone/pnpm-workspace.yaml
+++ b/apps/dsh-edge/standalone/pnpm-workspace.yaml
@@ -193,6 +193,7 @@ patchedDependencies:
   '@deepseek-ai/dsh-api-gateway@0.1.1-rc.2': patches/@deepseek-ai__dsh-api-gateway@0.1.1-rc.2.patch
   '@deepseek-ai/dsh-llm-deepseek@0.1.1-rc.2': patches/@deepseek-ai__dsh-llm-deepseek@0.1.1-rc.2.patch
   '@deepseek-ai/dsh-llm@0.1.1-rc.2': patches/@deepseek-ai__dsh-llm@0.1.1-rc.2.patch
+  '@deepseek-ai/dsh-message-feedback@0.1.1-rc.2': patches/@deepseek-ai__dsh-message-feedback@0.1.1-rc.2.patch
   '@deepseek-ai/dsh-sandbox@0.1.1-rc.2': patches/@deepseek-ai__dsh-sandbox@0.1.1-rc.2.patch
   '@deepseek-ai/dsh-session-persistence@0.1.1-rc.2': patches/@deepseek-ai__dsh-session-persistence@0.1.1-rc.2.patch
   '@deepseek-ai/dsh-web-search-deepseek@0.1.1-rc.2': patches/@deepseek-ai__dsh-web-search-deepseek@0.1.1-rc.2.patch

--- a/apps/dsh-edge/standalone/scripts/assemble-standalone-web.mjs
+++ b/apps/dsh-edge/standalone/scripts/assemble-standalone-web.mjs
@@ -39,7 +39,6 @@ const edgeExcludedPackages = new Set([
   '@deepseek-ai/dsh-client-hmr',
   '@deepseek-ai/dsh-cordis-client-runner',
   '@deepseek-ai/dsh-client-ui-cordis',
-  '@deepseek-ai/dsh-client-ui-message-feedback',
   '@deepseek-ai/dsh-client-ui-plan',
   '@deepseek-ai/dsh-client-ui-reference',
   '@deepseek-ai/dsh-client-ui-settings-plugin-inventory',

--- a/apps/dsh-edge/standalone/scripts/verify-standalone.mjs
+++ b/apps/dsh-edge/standalone/scripts/verify-standalone.mjs
@@ -18,7 +18,6 @@ const excludedClientPackages = [
   '@deepseek-ai/dsh-client-hmr',
   '@deepseek-ai/dsh-cordis-client-runner',
   '@deepseek-ai/dsh-client-ui-cordis',
-  '@deepseek-ai/dsh-client-ui-message-feedback',
   '@deepseek-ai/dsh-client-ui-plan',
   '@deepseek-ai/dsh-client-ui-reference',
   '@deepseek-ai/dsh-client-ui-settings-plugin-inventory',

--- a/apps/dsh-edge/tests/do-message-feedback-store.spec.ts
+++ b/apps/dsh-edge/tests/do-message-feedback-store.spec.ts
@@ -1,0 +1,90 @@
+import { Context } from '@deepseek-ai/cordis'
+import MessageFeedbackService, {
+  type MessageFeedbackRow,
+  type MessageFeedbackStore,
+} from '@deepseek-ai/dsh-message-feedback'
+import { describe, expect, it } from 'vitest'
+import { DurableObjectMessageFeedbackStore } from '../src/do-message-feedback-store.ts'
+
+const row: MessageFeedbackRow = {
+  session: { createdAt: 1, cwd: '/workspace' },
+  items: [{
+    messageId: 'message-1' as MessageFeedbackRow['items'][number]['messageId'],
+    rating: 'positive',
+    note: 'useful',
+    version: 'd7f6edc4-859e-4a80-a025-86b5e3d31dcb' as MessageFeedbackRow['items'][number]['version'],
+    createdAt: 2,
+    updatedAt: 2,
+  }],
+}
+
+function createMockStorage(initial: Record<string, unknown> = {}): DurableObjectStorage & {
+  readonly values: Map<string, unknown>
+  readonly listCalls: { count: number }
+} {
+  const values = new Map(Object.entries(initial))
+  const listCalls = { count: 0 }
+  return {
+    values,
+    listCalls,
+    get: (key: string) => Promise.resolve(values.get(key)),
+    put: (key: string, value: unknown) => { values.set(key, value); return Promise.resolve() },
+    list: () => { listCalls.count += 1; throw new Error('message feedback must use point reads') },
+  } as unknown as DurableObjectStorage & {
+    readonly values: Map<string, unknown>
+    readonly listCalls: { count: number }
+  }
+}
+
+describe('DurableObjectMessageFeedbackStore', () => {
+  it('installs the upstream service without opening storage-domain', async () => {
+    const context = new Context()
+    let domainOpenCalls = 0
+    context.provide('storageDomain', {
+      open: () => {
+        domainOpenCalls += 1
+        return Promise.reject(new Error('message feedback must use the injected store'))
+      },
+    } as never)
+    context.provide('sessionPersistence', {} as never)
+    context.provide('sessions', {} as never)
+    const store: MessageFeedbackStore = {
+      get: () => Promise.resolve(undefined),
+      put: () => Promise.resolve(),
+    }
+
+    await context.plugin(MessageFeedbackService, { maxNoteBytes: 8_192, store })
+    expect(context.messageFeedback).toBeDefined()
+    expect(domainOpenCalls).toBe(0)
+    await context.fiber.dispose()
+  })
+
+  it('reads and writes the existing storage-domain keys without listing the unit', async () => {
+    const storage = createMockStorage()
+    const store = new DurableObjectMessageFeedbackStore(storage)
+    await store.put('session-1', row)
+
+    expect(storage.values.get('dsh-kv:message_feedback:__version__')).toBe(0)
+    expect(await store.get('session-1')).toEqual(row)
+    expect(storage.listCalls.count).toBe(0)
+  })
+
+  it('rejects malformed point-read rows', async () => {
+    const storage = createMockStorage({
+      'dsh-kv:message_feedback:__version__': 0,
+      'dsh-kv:message_feedback:sessions:session-1': { items: 'invalid' },
+    })
+    const store = new DurableObjectMessageFeedbackStore(storage)
+
+    await expect(store.get('session-1')).rejects.toMatchObject({ code: 'malformed-medium' })
+    expect(storage.listCalls.count).toBe(0)
+  })
+
+  it('preserves the storage-domain version guard', async () => {
+    const storage = createMockStorage({ 'dsh-kv:message_feedback:__version__': 1 })
+    const store = new DurableObjectMessageFeedbackStore(storage)
+
+    await expect(store.get('session-1')).rejects.toMatchObject({ code: 'version-mismatch' })
+    expect(storage.listCalls.count).toBe(0)
+  })
+})

--- a/apps/dsh-edge/tests/session.browser.snapshot.mjs
+++ b/apps/dsh-edge/tests/session.browser.snapshot.mjs
@@ -172,6 +172,17 @@ describe('dsh-edge assembled browser snapshot', () => {
         { timeout: 30_000 },
       ).toBeGreaterThanOrEqual(1)
       await expect.poll(() => composer.isEnabled(), { timeout: 15_000 }).toBe(true)
+      const feedbackResponse = page.waitForResponse(response =>
+        response.request().method() === 'POST'
+        && new URL(response.url()).pathname === '/api/messageFeedback/put')
+      await page.getByRole('button', { name: 'Good response', exact: true }).click()
+      const feedbackWire = await (await feedbackResponse).json()
+      expect(feedbackWire.result.ok).toBe(true)
+      expect(feedbackWire.result.value.ok).toBe(true)
+      await expect.poll(
+        () => page.getByRole('button', { name: 'Remove rating', exact: true }).count(),
+        { timeout: 15_000 },
+      ).toBe(1)
 
       // The client only increments a fork title when the source already has a
       // durable title projection. Seed that upstream state through the same

--- a/apps/dsh-edge/tests/session.integration.mjs
+++ b/apps/dsh-edge/tests/session.integration.mjs
@@ -301,12 +301,14 @@ try {
   const feedbackMessageId = firstEvents
     .find(event => event.type === 'assistant/message')?.data.message.id
   assert.equal(typeof feedbackMessageId, 'string')
+  // Exercise the service's 8 KiB note boundary with JSON's six-byte control escapes.
+  const maxFeedbackNote = '\u0001'.repeat(8_192)
   const savedFeedback = await typertRpc('messageFeedback', 'put', {
     request: {
       sessionId,
       messageId: feedbackMessageId,
       rating: 'positive',
-      note: 'Useful answer',
+      note: maxFeedbackNote,
       ifVersion: null,
     },
   })
@@ -316,7 +318,7 @@ try {
   assert.deepEqual(feedbackItem, {
     messageId: feedbackMessageId,
     rating: 'positive',
-    note: 'Useful answer',
+    note: maxFeedbackNote,
     version: feedbackItem.version,
     createdAt: feedbackItem.createdAt,
     updatedAt: feedbackItem.updatedAt,

--- a/apps/dsh-edge/tests/session.integration.mjs
+++ b/apps/dsh-edge/tests/session.integration.mjs
@@ -298,6 +298,36 @@ try {
   assert.equal(assistantText(firstEvents), 'remembered-alpha')
   assert.equal(firstEvents.at(-2).type, 'step/end')
   assert.deepEqual(firstEvents.at(-1).data.reason, { kind: 'completed' })
+  const feedbackMessageId = firstEvents
+    .find(event => event.type === 'assistant/message')?.data.message.id
+  assert.equal(typeof feedbackMessageId, 'string')
+  const savedFeedback = await typertRpc('messageFeedback', 'put', {
+    request: {
+      sessionId,
+      messageId: feedbackMessageId,
+      rating: 'positive',
+      note: 'Useful answer',
+      ifVersion: null,
+    },
+  })
+  assert.equal(savedFeedback.body.result.ok, true, JSON.stringify(savedFeedback.body))
+  assert.equal(savedFeedback.body.result.value.ok, true)
+  const feedbackItem = savedFeedback.body.result.value.value
+  assert.deepEqual(feedbackItem, {
+    messageId: feedbackMessageId,
+    rating: 'positive',
+    note: 'Useful answer',
+    version: feedbackItem.version,
+    createdAt: feedbackItem.createdAt,
+    updatedAt: feedbackItem.updatedAt,
+  })
+  const listedFeedback = await typertRpc('messageFeedback', 'list', {
+    request: { sessionId },
+  })
+  assert.deepEqual(listedFeedback.body.result.value, {
+    ok: true,
+    value: { items: [feedbackItem] },
+  })
 
   const secondEvents = await turn(sessionId, 'history check')
   assert.equal(assistantText(secondEvents), 'history-ok')
@@ -384,6 +414,13 @@ try {
   assert.equal(restored.response.status, 200)
   assert.equal(restored.body.session.status, 'idle')
   assert.equal(Object.hasOwn(restored.body, 'messages'), false)
+  const restoredFeedback = await typertRpc('messageFeedback', 'list', {
+    request: { sessionId },
+  })
+  assert.deepEqual(restoredFeedback.body.result.value, {
+    ok: true,
+    value: { items: [feedbackItem] },
+  })
   const restoredFile = await request('/api/workspace/file?path=/workspace/session.txt')
   assert.equal(restoredFile.status, 200)
   assert.equal(await restoredFile.text(), 'cloudflare-tool-value')
@@ -1362,6 +1399,21 @@ async function rpc(method, payload) {
       rpcId,
       method,
       payload,
+    }),
+  })
+  assert.equal(result.body.rpcId, rpcId)
+  return { ...result, rpcId }
+}
+
+async function typertRpc(namespace, method, args) {
+  const rpcId = crypto.randomUUID()
+  const result = await jsonRequest(`/api/${namespace}/${method}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      type: 'client-request',
+      rpcId,
+      payload: { args },
     }),
   })
   assert.equal(result.body.rpcId, rpcId)

--- a/apps/dsh-edge/tests/snapshots/edge-browser.expected.md
+++ b/apps/dsh-edge/tests/snapshots/edge-browser.expected.md
@@ -14,6 +14,10 @@
 - paragraph: remembered-alpha
 - button "Copy":
   - img
+- button "Good response":
+  - img
+- button "Bad response":
+  - img
 - button "Branch into a new conversation":
   - img
 - text: {{clock}}Ran for {{metric}} TTFT {{metric}} {{metric}}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -117,6 +117,9 @@ importers:
       '@deepseek-ai/dsh-llm-deepseek':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(patch_hash=cb1b831ea1c82f52e4f4e859056561ba1f60e148a4fdd60e65fbcf5824e50a21)(3253d8bc1d8c30bbca52f480e02637f2)
+      '@deepseek-ai/dsh-message-feedback':
+        specifier: 0.1.1-rc.2
+        version: 0.1.1-rc.2(619e8897574909434c2c18a5adadde17)
       '@deepseek-ai/dsh-output-retention':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,6 +9,7 @@ pnpmfileChecksum: sha256-cyrkM8xkR2XQ7niS5YNTDeRZQBAUJM2gr/ZaPfZqVBc=
 patchedDependencies:
   '@deepseek-ai/dsh-llm-deepseek@0.1.1-rc.2': cb1b831ea1c82f52e4f4e859056561ba1f60e148a4fdd60e65fbcf5824e50a21
   '@deepseek-ai/dsh-llm@0.1.1-rc.2': 1837c37e725fba94ea746dffef5bc6687e19c8446533e71d53de7b2b064e0a84
+  '@deepseek-ai/dsh-message-feedback@0.1.1-rc.2': 51f6c4d04d8910893392fcf547177fcf6160fa21370bb0e478da514260edb182
   '@deepseek-ai/dsh-session-persistence@0.1.1-rc.2': ae9f4b486992d7dd8c625f24562b589c483d14b5f5b56d71855df0a44450a149
   '@deepseek-ai/dsh-web-search-deepseek@0.1.1-rc.2': eb7c0136d390f3ab6b70c282de0bfc15d9f483ea9558c3fdc4c85b657146ca87
   '@deepseek-ai/dsh-workspace@0.1.1-rc.2': 0775c845fe34861357511d68a42c3d3936d8890bf439c8928beb4a2b96cedb86
@@ -107,7 +108,7 @@ importers:
         version: 0.1.1-rc.2(96f94b0b90aa520c6f6eaef05e86c447)
       '@deepseek-ai/dsh-host-apiproxy':
         specifier: 0.1.1-rc.2
-        version: 0.1.1-rc.2(9f6a6c0d47650236eb0b176a447933ed)
+        version: 0.1.1-rc.2(08a0cf411fb9eae429ee43ea5685c22e)
       '@deepseek-ai/dsh-launch-environment':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
@@ -119,7 +120,7 @@ importers:
         version: 0.1.1-rc.2(patch_hash=cb1b831ea1c82f52e4f4e859056561ba1f60e148a4fdd60e65fbcf5824e50a21)(3253d8bc1d8c30bbca52f480e02637f2)
       '@deepseek-ai/dsh-message-feedback':
         specifier: 0.1.1-rc.2
-        version: 0.1.1-rc.2(619e8897574909434c2c18a5adadde17)
+        version: 0.1.1-rc.2(patch_hash=51f6c4d04d8910893392fcf547177fcf6160fa21370bb0e478da514260edb182)(619e8897574909434c2c18a5adadde17)
       '@deepseek-ai/dsh-output-retention':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
@@ -237,19 +238,19 @@ importers:
         version: 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-client-locale':
         specifier: 0.1.1-rc.2
-        version: 0.1.1-rc.2(0803ec1caa0ebbc7804efb9e73ec73cd)
+        version: 0.1.1-rc.2(bf3156325876fd682f233fc76bf98887)
       '@deepseek-ai/dsh-client-runtime':
         specifier: 0.1.1-rc.2
-        version: 0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b)
+        version: 0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083)
       '@deepseek-ai/dsh-client-test-runtime':
         specifier: 0.1.1-rc.2
-        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b))(@deepseek-ai/dsh-client-ui-renderer@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(react@18.3.1))(@deepseek-ai/dsh-client-ui-slots@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-apiproxy@0.1.1-rc.2)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@types/node@22.20.1)(@types/react@18.3.31)(jsdom@29.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083))(@deepseek-ai/dsh-client-ui-renderer@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(react@18.3.1))(@deepseek-ai/dsh-client-ui-slots@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-apiproxy@0.1.1-rc.2)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@types/node@22.20.1)(@types/react@18.3.31)(jsdom@29.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))
       '@deepseek-ai/dsh-client-ui-primitives':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-client-ui-settings':
         specifier: 0.1.1-rc.2
-        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+        version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-client-ui-slots':
         specifier: 0.1.1-rc.2
         version: 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
@@ -3415,7 +3416,7 @@ snapshots:
       '@deepseek-ai/dsh-typert-protocol': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-typert-registry': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
 
-  '@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)':
+  '@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f)
@@ -3429,7 +3430,7 @@ snapshots:
       '@deepseek-ai/dsh-host-plugin-inventory': 0.1.1-rc.2(@deepseek-ai/cordis-plugin-loader@1.0.2)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-typert-protocol@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.1-rc.2(patch_hash=1837c37e725fba94ea746dffef5bc6687e19c8446533e71d53de7b2b064e0a84)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
-      '@deepseek-ai/dsh-message-feedback': 0.1.1-rc.2(619e8897574909434c2c18a5adadde17)
+      '@deepseek-ai/dsh-message-feedback': 0.1.1-rc.2(patch_hash=51f6c4d04d8910893392fcf547177fcf6160fa21370bb0e478da514260edb182)(619e8897574909434c2c18a5adadde17)
       '@deepseek-ai/dsh-session': 0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8)
       '@deepseek-ai/dsh-session-persistence': 0.1.1-rc.2(patch_hash=ae9f4b486992d7dd8c625f24562b589c483d14b5f5b56d71855df0a44450a149)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-session@0.1.1-rc.2(3ebc4d9910f6f14a2209af60c642fbb8))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-session-reference': 0.1.1-rc.2(0a2211595c200a2c74dc8c02efabef61)
@@ -3458,7 +3459,7 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-commands': 0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a)
-      '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.2(9f6a6c0d47650236eb0b176a447933ed)
+      '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.2(08a0cf411fb9eae429ee43ea5685c22e)
       '@deepseek-ai/dsh-host-webserver': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.1-rc.2(patch_hash=1837c37e725fba94ea746dffef5bc6687e19c8446533e71d53de7b2b064e0a84)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
@@ -3470,26 +3471,26 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@deepseek-ai/dsh-client-locale@0.1.1-rc.2(0803ec1caa0ebbc7804efb9e73ec73cd)':
+  '@deepseek-ai/dsh-client-locale@0.1.1-rc.2(bf3156325876fd682f233fc76bf98887)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b)
-      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083)
+      '@deepseek-ai/dsh-client-ui-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b)':
+  '@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
       '@deepseek-ai/dsh-commands': 0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a)
-      '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.2(9f6a6c0d47650236eb0b176a447933ed)
+      '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.2(08a0cf411fb9eae429ee43ea5685c22e)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-llm': 0.1.1-rc.2(patch_hash=1837c37e725fba94ea746dffef5bc6687e19c8446533e71d53de7b2b064e0a84)(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-attachment@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-timeout@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))
       '@deepseek-ai/dsh-llm-retry': 0.1.1-rc.2(d324c4f062c2281f5d775317220bb9ca)
@@ -3505,13 +3506,13 @@ snapshots:
       - '@types/react'
       - react
 
-  '@deepseek-ai/dsh-client-test-runtime@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b))(@deepseek-ai/dsh-client-ui-renderer@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(react@18.3.1))(@deepseek-ai/dsh-client-ui-slots@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-apiproxy@0.1.1-rc.2)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@types/node@22.20.1)(@types/react@18.3.31)(jsdom@29.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))':
+  '@deepseek-ai/dsh-client-test-runtime@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083))(@deepseek-ai/dsh-client-ui-renderer@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(react@18.3.1))(@deepseek-ai/dsh-client-ui-slots@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-host-apiproxy@0.1.1-rc.2)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@types/node@22.20.1)(@types/react@18.3.31)(jsdom@29.1.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(vite@8.2.2(@types/node@22.20.1)(esbuild@0.28.1)(yaml@2.9.0))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b)
-      '@deepseek-ai/dsh-client-ui-renderer': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(react@18.3.1)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083)
+      '@deepseek-ai/dsh-client-ui-renderer': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(react@18.3.1)
       '@deepseek-ai/dsh-client-ui-slots': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
-      '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.2(9f6a6c0d47650236eb0b176a447933ed)
+      '@deepseek-ai/dsh-host-apiproxy': 0.1.1-rc.2(08a0cf411fb9eae429ee43ea5685c22e)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@testing-library/dom': 10.4.1
       '@testing-library/react': 16.3.2(@testing-library/dom@10.4.1)(@types/react@18.3.31)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -3562,21 +3563,21 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@deepseek-ai/dsh-client-ui-renderer@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(react@18.3.1)':
+  '@deepseek-ai/dsh-client-ui-renderer@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(react@18.3.1)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       use-sync-external-store: 1.2.0(react@18.3.1)
     transitivePeerDependencies:
       - react
 
-  '@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))':
+  '@deepseek-ai/dsh-client-ui-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-api-remotes@0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c))(@deepseek-ai/dsh-client-connection@0.1.1-rc.2)(@deepseek-ai/dsh-client-runtime@0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/dsh-settings@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-client-connection': 0.1.1-rc.2(3dcdb457eea7bdeed55c4b795255ba2e)
-      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(f17169c68e8145b0f117911e7bad521b)
+      '@deepseek-ai/dsh-client-runtime': 0.1.1-rc.2(d7d20d72412c553b1dae4542b51a1083)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
       '@deepseek-ai/dsh-settings': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))(@deepseek-ai/schemastery@3.18.1)
       '@deepseek-ai/schemastery': 3.18.1
@@ -3701,13 +3702,13 @@ snapshots:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-invariants': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)
 
-  '@deepseek-ai/dsh-host-apiproxy@0.1.1-rc.2(9f6a6c0d47650236eb0b176a447933ed)':
+  '@deepseek-ai/dsh-host-apiproxy@0.1.1-rc.2(08a0cf411fb9eae429ee43ea5685c22e)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-agent': 0.1.1-rc.2(faa50b55d876ba41a650f10913906e6f)
       '@deepseek-ai/dsh-agent-default-model': 0.1.1-rc.2(cb2f1581451b2fa42233c9a627f51ae3)
       '@deepseek-ai/dsh-agent-presets': 0.1.1-rc.2(d9f3616961e6351fcb70538e475fb6a0)
-      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(761b07ff4dfaf22b44978beb862d4d44)
+      '@deepseek-ai/dsh-api-remotes': 0.1.1-rc.2(82fce1af395bebf244fcf254f65c5c2c)
       '@deepseek-ai/dsh-attachment': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-brand@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)))(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/dsh-commands': 0.1.1-rc.2(83b1a6f9e286864ee72ad4d52555645a)
@@ -3827,7 +3828,7 @@ snapshots:
       '@deepseek-ai/dsh-timeout': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))
       '@deepseek-ai/schemastery': 3.18.1
 
-  '@deepseek-ai/dsh-message-feedback@0.1.1-rc.2(619e8897574909434c2c18a5adadde17)':
+  '@deepseek-ai/dsh-message-feedback@0.1.1-rc.2(patch_hash=51f6c4d04d8910893392fcf547177fcf6160fa21370bb0e478da514260edb182)(619e8897574909434c2c18a5adadde17)':
     dependencies:
       '@deepseek-ai/cordis': 4.0.1(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-brand': 0.1.1-rc.2(@deepseek-ai/cordis@4.0.1)(@deepseek-ai/dsh-invariants@0.1.1-rc.2(@deepseek-ai/cordis@4.0.1))

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -14,6 +14,7 @@ allowBuilds:
 patchedDependencies:
   '@deepseek-ai/dsh-llm@0.1.1-rc.2': apps/dsh-edge/standalone/patches/@deepseek-ai__dsh-llm@0.1.1-rc.2.patch
   '@deepseek-ai/dsh-llm-deepseek@0.1.1-rc.2': apps/dsh-edge/standalone/patches/@deepseek-ai__dsh-llm-deepseek@0.1.1-rc.2.patch
+  '@deepseek-ai/dsh-message-feedback@0.1.1-rc.2': apps/dsh-edge/standalone/patches/@deepseek-ai__dsh-message-feedback@0.1.1-rc.2.patch
   '@deepseek-ai/dsh-session-persistence@0.1.1-rc.2': apps/dsh-edge/standalone/patches/@deepseek-ai__dsh-session-persistence@0.1.1-rc.2.patch
   '@deepseek-ai/dsh-web-search-deepseek@0.1.1-rc.2': apps/dsh-edge/standalone/patches/@deepseek-ai__dsh-web-search-deepseek@0.1.1-rc.2.patch
   '@deepseek-ai/dsh-workspace@0.1.1-rc.2': apps/dsh-edge/standalone/patches/@deepseek-ai__dsh-workspace@0.1.1-rc.2.patch


### PR DESCRIPTION
## Summary

- install the upstream `MessageFeedbackService` with an 8 KiB note limit and register its Host Typert contract
- include the exact message-feedback dependency in the root and standalone closures
- enable the upstream browser feedback plugin so assistant messages expose positive/negative ratings and optional notes
- cover Typert writes, reads, Durable Object restart persistence, and the visible browser controls

## Validation

- `pnpm run check`
- `pnpm run build`
- `pnpm --filter dsh-edge run test:integration`
- `DSH_EDGE_PLAYWRIGHT_CHANNEL=chrome pnpm --filter dsh-edge run test:snapshot`
- packed artifact installation and Direct/Isolated startup verification
- manual Direct-mode browser verification

Closes #112