### PR TITLE
release: dsh-edge 0.8.0

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.8.0.i18n.yaml
+++ b/docs/releases/0.8.0.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.8.0.md: d5b54e41874b0480ab3b84053d7a7fec1e162612
+0.8.0.zh.md: ed049fb0180280f80cd58ee4616c9dccf7b57990

--- a/docs/releases/0.8.0.md
+++ b/docs/releases/0.8.0.md
@@ -1,0 +1,25 @@
+## dsh-edge 0.8.0
+
+Message feedback, bounded web fetching, and an Edge agent persona aligned with the shipped toolset. Roadmap Tier 1 is complete.
+
+### Added
+
+- **Message feedback**: assistant messages now expose Good response and Bad response controls through the upstream Web client. Ratings and optional notes flow through the Typert gateway and persist in Durable Object storage without scanning all retained feedback rows.
+- **Web fetch**: the model can use the upstream `web_fetch` tool to retrieve public HTTP(S) pages and convert HTML to Markdown inside the Worker. Search and fetch share the existing 30-second tool-call timeout policy.
+
+### Changed
+
+- **Edge agent persona**: the deployment prompt now prefers `read`, `write`, `edit`, and `read_image` for workspace files, reserves bash for shell commands, and advertises the available Web and goal tools.
+
+### Security and limits
+
+- **Bounded public fetching**: `web_fetch` rejects embedded credentials, IP literals, and local naming scopes before requests and allowed redirect hops. It bounds URL length, response bytes, decoded characters, redirects, and elapsed time, and uses Cloudflare's strictly-public global fetch path to prevent DNS changes from reaching private or same-zone targets.
+- **Durable feedback storage**: feedback uses versioned per-session Durable Object records with point reads. Feedback notes are capped at 8 KiB, and malformed persisted rows fail closed.
+
+### Documentation
+
+- **Wiki consolidation**: refreshed the English and Chinese READMEs with capability-wiki links and removed the superseded Agent Notes from the repository.
+
+### Dependencies
+
+- Added `@deepseek-ai/dsh-message-feedback`, `@deepseek-ai/dsh-web-fetch-http`, and `@mixmark-io/domino`.

--- a/docs/releases/0.8.0.zh.md
+++ b/docs/releases/0.8.0.zh.md
@@ -1,0 +1,25 @@
+## dsh-edge 0.8.0
+
+消息反馈、带边界的网页抓取，以及与已发布工具集一致的 Edge agent persona。路线图第一层现已完成。
+
+### 新增
+
+- **消息反馈**：assistant 消息现在通过上游 Web client 提供“Good response”和“Bad response”控件。评分和可选备注经 Typert 网关流转，并持久化到 Durable Object storage，无需扫描全部历史反馈记录。
+- **网页抓取**：模型现在可以使用上游 `web_fetch` 工具获取公开 HTTP(S) 页面，并在 Worker 内把 HTML 转换为 Markdown。搜索与抓取共用现有的 30 秒 tool-call timeout 策略。
+
+### 变更
+
+- **Edge agent persona**：部署提示词现在优先使用 `read`、`write`、`edit` 和 `read_image` 处理 workspace 文件，将 bash 保留给 shell 命令，并说明可用的 Web 与 goal 工具。
+
+### 安全性与限制
+
+- **有界公开抓取**：`web_fetch` 在请求及允许的重定向跳转前拒绝嵌入凭据、IP literal 和本地命名范围。它限制 URL 长度、response 字节数、解码字符数、重定向次数和耗时，并使用 Cloudflare strictly-public global fetch 路径，防止 DNS 变化触达私网或同区目标。
+- **持久化反馈存储**：反馈使用带版本的逐 session Durable Object 记录和 point read。反馈备注上限为 8 KiB，持久化记录格式异常时采用 fail-closed 行为。
+
+### 文档
+
+- **Wiki 整合**：更新中英文 README，补充能力 wiki 链接，并从仓库中移除已被取代的 Agent Notes。
+
+### 依赖
+
+- 新增 `@deepseek-ai/dsh-message-feedback`、`@deepseek-ai/dsh-web-fetch-http` 和 `@mixmark-io/domino`。


### PR DESCRIPTION
## Summary

- bump the sole dsh-edge release version source to 0.8.0
- add authoritative English and Chinese release notes for Roadmap Tier 1
- cover message feedback, bounded web fetching, the updated Edge persona, and documentation consolidation

## Validation

- pnpm exec vitest run --project edge-runtime apps/dsh-edge/tests/repository-metadata.spec.ts apps/dsh-edge/tests/workflows.spec.ts apps/dsh-edge/tests/publish.spec.ts
- pnpm run check
- pnpm --dir apps/dsh-edge pack --pack-destination <temp>
- pnpm --filter dsh-edge run pack:verify <temp>/dsh-edge-0.8.0.tgz
- git diff --check

## After merge

Create and push `dsh-edge-v0.8.0`; the release workflow will verify, publish the npm package, and create the matching GitHub Release.