### PR TITLE
release: dsh-edge 0.9.0

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.8.0",
+  "version": "0.9.0",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.9.0.i18n.yaml
+++ b/docs/releases/0.9.0.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.9.0.md: c0ef1fe35f6535c9a9fdbc5d08ade13da3de4e93
+0.9.0.zh.md: dce97fed715694e4399cdb76564943aacfbc8f2e

--- a/docs/releases/0.9.0.md
+++ b/docs/releases/0.9.0.md
@@ -1,0 +1,18 @@
+## dsh-edge 0.9.0
+
+Skill tool integration and upstream command registry, completing the Typert gateway coverage.
+
+### Added
+
+- **Skill tool**: the model gains the `skill` tool for loading named reusable instructions during a conversation. `SkillRegistry`, `ToolSkill`, and a custom `EdgeSkillProvider` backed by Durable Object KV storage are installed as cordis plugins. Skill metadata and content are stored under disjoint key prefixes (`dsh-edge:skill-meta:*` / `dsh-edge:skill-body:*`) so catalog reads stay lightweight.
+- **Skill CRUD API**: owner-authenticated `GET/PUT/DELETE /api/skills` endpoint for managing skill definitions. Input validation bounds name (128 chars), description (512), whenToUse (1024), and content (65 KiB).
+- **Skill client UI**: the upstream `dsh-client-ui-skill` plugin (now in the 34-plugin client bundle) provides a `/` input trigger for skill invocation and renders `skill` tool calls as collapsible instruction cards.
+- **CommandRegistry**: the upstream `CommandRuntime` (`dsh-commands`) is installed after `AgentRegistry` with its TYPERT registered. `commands/list` and `commands/execute` are auto-routed by `TypertGatewayService`.
+
+### Removed
+
+- **`handleEdgeRemote` stub**: the entire `edge-remotes.ts` file and its test are deleted. No manual RPC stubs remain in the codebase — the Typert gateway now covers all client-server RPC endpoints.
+
+### Dependencies
+
+- Added `@deepseek-ai/dsh-skill`, `@deepseek-ai/dsh-tool-skill`, and `@deepseek-ai/dsh-commands`.

--- a/docs/releases/0.9.0.zh.md
+++ b/docs/releases/0.9.0.zh.md
@@ -1,0 +1,18 @@
+## dsh-edge 0.9.0
+
+技能工具集成和上游命令注册表，完成 Typert 网关全覆盖。
+
+### 新增
+
+- **技能工具**：模型获得 `skill` 工具，可在对话中加载命名的可复用指令。`SkillRegistry`、`ToolSkill` 和基于 Durable Object KV 存储的自定义 `EdgeSkillProvider` 作为 cordis 插件安装。技能元数据和内容存储在不相交的键前缀下（`dsh-edge:skill-meta:*` / `dsh-edge:skill-body:*`），保持目录读取轻量。
+- **技能 CRUD API**：owner 认证的 `GET/PUT/DELETE /api/skills` 端点，用于管理技能定义。输入校验限制 name（128 字符）、description（512）、whenToUse（1024）和 content（65 KiB）。
+- **技能客户端 UI**：上游 `dsh-client-ui-skill` 插件（现在是 34 个客户端插件之一）提供 `/` 输入触发器用于技能调用，并将 `skill` 工具调用渲染为可折叠的指令卡片。
+- **CommandRegistry**：上游 `CommandRuntime`（`dsh-commands`）安装在 `AgentRegistry` 之后并注册了 TYPERT。`commands/list` 和 `commands/execute` 由 `TypertGatewayService` 自动路由。
+
+### 移除
+
+- **`handleEdgeRemote` 桩**：整个 `edge-remotes.ts` 文件及其测试已删除。代码库中不再有手写 RPC 桩——Typert 网关现在覆盖所有客户端-服务端 RPC 端点。
+
+### 依赖
+
+- 新增 `@deepseek-ai/dsh-skill`、`@deepseek-ai/dsh-tool-skill` 和 `@deepseek-ai/dsh-commands`。


### PR DESCRIPTION
## Summary

- Bump version to 0.9.0
- Bilingual release notes (English + Chinese)

### What's in 0.9.0

- **Skill tool** (#121): SkillRegistry + EdgeSkillProvider (DO KV) + ToolSkill + `/api/skills` CRUD + client UI
- **CommandRegistry** (#122): upstream CommandRuntime installed, TYPERT registered, `handleEdgeRemote` stub removed

### Release procedure

After merge:
1. `git pull` on main
2. `git tag dsh-edge-v0.9.0 && git push origin dsh-edge-v0.9.0`
3. Tag push triggers `release-edge.yml` → npm publish + GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)