### PR TITLE
perf: route web fetch through the Workers fetch and drop undici

### DIFF
--- a/apps/dsh-edge/standalone/patches/@deepseek-ai__dsh-web-fetch-http@0.1.2-rc.1.patch
+++ b/apps/dsh-edge/standalone/patches/@deepseek-ai__dsh-web-fetch-http@0.1.2-rc.1.patch
@@ -1,13 +1,16 @@
 diff --git a/lib/index.js b/lib/index.js
-index 9c99aab33ee450d30768b8ee56e5779876b4fcf6..bc3417a87aaaa19bcd36b625ba6ff414314c0668 100644
+index 9c99aab33ee450d30768b8ee56e5779876b4fcf6..b7f7179f4e41e266ccb82cb86ed6e286246ff272 100644
 --- a/lib/index.js
 +++ b/lib/index.js
-@@ -4,6 +4,24 @@ import { deadline, timeoutOf } from "@deepseek-ai/dsh-timeout";
- import { lookup } from "node:dns/promises";
+@@ -1,9 +1,26 @@
+ import z from "@deepseek-ai/schemastery";
+ import { WebError } from "@deepseek-ai/dsh-web";
+ import { deadline, timeoutOf } from "@deepseek-ai/dsh-timeout";
+-import { lookup } from "node:dns/promises";
  import { isIP } from "node:net";
  import ipaddr from "ipaddr.js";
 +
-+const LOCAL_SUFFIXES = ['.local', '.localdomain', '.internal', '.home.arpa'];
++const LOCAL_SUFFIXES = ['.localhost', '.local', '.localdomain', '.internal', '.home.arpa'];
 +function isIpLiteral(hostname) {
 +	if (/^\d{1,3}(\.\d{1,3}){3}$/.test(hostname)) return true;
 +	if (hostname.startsWith('[') && hostname.endsWith(']')) return true;
@@ -27,7 +30,83 @@ index 9c99aab33ee450d30768b8ee56e5779876b4fcf6..bc3417a87aaaa19bcd36b625ba6ff414
  //#region lib/types/network.js
  /**
  * Public-network resolution and address-pinned HTTP transport for `web-fetch-http`.
-@@ -444,6 +462,7 @@ var HttpFetchProvider = class {
+@@ -51,30 +68,17 @@ function isPublicIpAddress(input) {
+ * @param resolver - lookup implementation, overridden only by focused tests.
+ * @returns the validated, non-empty address set.
+ */
+-async function resolvePublicAddresses(hostname, signal, resolver = lookup) {
++async function resolvePublicAddresses(hostname, signal, resolver) {
++	void signal;
++	void resolver;
+ 	const unbracketed = stripIpv6Brackets(hostname);
+ 	const literalFamily = isIP(unbracketed);
+-	const resolved = literalFamily === 0 ? await raceWithSignal(resolver(unbracketed, {
+-		all: true,
+-		order: "verbatim"
+-	}), signal) : [{
++	if (literalFamily === 0) return [];
++	if (!isPublicIpAddress(unbracketed)) throw new WebError(`URL hostname "${hostname}" resolves to a non-public IP address`, "WEB_BLOCKED_URL");
++	return [{
+ 		address: unbracketed,
+ 		family: literalFamily
+ 	}];
+-	if (resolved.length === 0) throw new WebError(`hostname "${hostname}" resolved to no addresses`, "WEB_PROVIDER_ERROR");
+-	const nat64Prefixes = resolved.some((entry) => entry.family === 6 && isIP(entry.address) === 6) ? await discoverNat64Prefixes(signal, resolver) : [];
+-	const addresses = [];
+-	for (const entry of resolved) {
+-		if (entry.family !== 4 && entry.family !== 6 || isIP(entry.address) !== entry.family) throw new WebError(`hostname "${hostname}" resolved to an invalid IP address`, "WEB_PROVIDER_ERROR");
+-		if (!isPublicIpAddress(entry.address)) throw new WebError(`URL hostname "${hostname}" resolves to a non-public IP address`, "WEB_BLOCKED_URL");
+-		const translatedIpv4 = translatedIpv4Address(entry.address, nat64Prefixes);
+-		if (translatedIpv4 !== void 0 && !isPublicIpAddress(translatedIpv4)) throw new WebError(`URL hostname "${hostname}" resolves through NAT64 to a non-public IPv4 address`, "WEB_BLOCKED_URL");
+-		addresses.push({
+-			address: entry.address,
+-			family: entry.family
+-		});
+-	}
+-	return addresses;
+ }
+ /** Discover the active DNS64 prefix set using RFC 7050's reserved hostname. */
+ async function discoverNat64Prefixes(signal, resolver) {
+@@ -131,28 +135,16 @@ function embeddedIpv4Address(bytes, prefixLength) {
+ * @returns a response plus the dispatcher disposer its consumer must call.
+ */
+ async function requestPinned(url, addresses, headers, signal) {
+-	const { Agent, fetch } = await import("undici");
+-	const dispatcher = new Agent({
+-		autoSelectFamily: true,
+-		connect: { lookup: createPinnedLookup(addresses) }
+-	});
+-	try {
+-		return {
+-			response: await fetch(url, {
+-				method: "GET",
+-				redirect: "manual",
+-				headers,
+-				signal,
+-				dispatcher
+-			}),
+-			close: async () => {
+-				await dispatcher.close();
+-			}
+-		};
+-	} catch (error) {
+-		await dispatcher.close();
+-		throw error;
+-	}
++	void addresses;
++	return {
++		response: await fetch(url, {
++			method: "GET",
++			redirect: "manual",
++			headers,
++			signal
++		}),
++		close: async () => {}
++	};
+ }
+ /** Production network operations kept as an object so provider tests can replace resolution only. */
+ const publicHttpNetwork = {
+@@ -444,6 +436,7 @@ var HttpFetchProvider = class {
  		}
  	}
  	async requestOnce(url, signal) {

--- a/apps/dsh-edge/standalone/patches/audit.json
+++ b/apps/dsh-edge/standalone/patches/audit.json
@@ -26,8 +26,8 @@
   },
   {
     "package": "@deepseek-ai/dsh-web-fetch-http",
-    "rationale": "Reject IP literals and local naming scopes before every HTTP request, including redirected requests. Together with the Worker's global_fetch_strictly_public flag, this keeps model-selected URLs on the public-Internet path and blocks local-development SSRF.",
-    "removeWhen": "The published HTTP fetch provider exposes an equivalent per-hop public-target policy and the Edge private-target assertions pass without this patch."
+    "rationale": "Reject IP literals and local naming scopes before every HTTP request, including redirected requests, and route requests through the Workers global fetch instead of the upstream DNS-pinned undici transport. Cloudflare Workers cannot run undici Agent or node:dns lookups; the platform's global_fetch_strictly_public setting blocks private destinations after DNS resolution, which covers the rebinding attack the pinned transport defends against, and dropping undici removes about 175 KiB of gzip weight.",
+    "removeWhen": "The published HTTP fetch provider exposes a platform-fetch transport (or injectable transport seam) with an equivalent per-hop public-target policy, and the Edge private-target assertions pass without this patch."
   },
   {
     "package": "@deepseek-ai/dsh-web-search-deepseek",

--- a/apps/dsh-edge/standalone/pnpm-lock.yaml
+++ b/apps/dsh-edge/standalone/pnpm-lock.yaml
@@ -13,7 +13,7 @@ patchedDependencies:
   '@deepseek-ai/dsh-message-feedback@0.1.2-rc.1': 74241acf25fcdc79a248d1510d3d2427befba3f0bf57da4ffab768065f5a8cd1
   '@deepseek-ai/dsh-session-persistence@0.1.2-rc.1': 1fc50721353748d4c7e0da2bb0ebf5eeecb5aa76aaa2d15f131e5ebbdbfcd633
   '@deepseek-ai/dsh-tool-web@0.1.2-rc.1': 359115e326d2ab890bc6c25e3e7672cda55ea87a74af80369a8cb411b7ae306c
-  '@deepseek-ai/dsh-web-fetch-http@0.1.2-rc.1': dfca34998ca1c2b3676f8a98fc5a02cc8590b1247d05a936cc7b2189ec0c6548
+  '@deepseek-ai/dsh-web-fetch-http@0.1.2-rc.1': ccd9c880b7bc79b388925ac30be3f7e722d82e571ce13dfb2c444eaf992325d0
   '@deepseek-ai/dsh-web-search-deepseek@0.1.2-rc.1': 8fc8fbf566dc108b9d2526ce27516a815102ac9599c28f14ecb909aef021e248
   '@deepseek-ai/dsh-workspace@0.1.2-rc.1': 1610ae8e37027b67c3804cc5278cb4cdbabef5d8d0a439d71ddd1da23bae76e6
 
@@ -209,7 +209,7 @@ importers:
         version: 0.1.2-rc.1(411417c349cb659cd1fd03d0dcda23b2)
       '@deepseek-ai/dsh-web-fetch-http':
         specifier: 0.1.2-rc.1
-        version: 0.1.2-rc.1(patch_hash=dfca34998ca1c2b3676f8a98fc5a02cc8590b1247d05a936cc7b2189ec0c6548)(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-timeout@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-web@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2)))
+        version: 0.1.2-rc.1(patch_hash=ccd9c880b7bc79b388925ac30be3f7e722d82e571ce13dfb2c444eaf992325d0)(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-timeout@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-web@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2)))
       '@deepseek-ai/dsh-web-frontend':
         specifier: 0.1.2-rc.1
         version: 0.1.2-rc.1
@@ -5104,7 +5104,7 @@ snapshots:
       '@deepseek-ai/dsh-user-approval': 0.1.2-rc.1(225691206e32bf17943f9ca0a6a23fd7)
       '@deepseek-ai/dsh-user-questions': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-agent@0.1.2-rc.1(717cb1113bc0278a9ba75fdbe6b85d08))(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-scope@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-invariants@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)))
       '@deepseek-ai/dsh-web': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2))
-      '@deepseek-ai/dsh-web-fetch-http': 0.1.2-rc.1(patch_hash=dfca34998ca1c2b3676f8a98fc5a02cc8590b1247d05a936cc7b2189ec0c6548)(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-timeout@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-web@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2)))
+      '@deepseek-ai/dsh-web-fetch-http': 0.1.2-rc.1(patch_hash=ccd9c880b7bc79b388925ac30be3f7e722d82e571ce13dfb2c444eaf992325d0)(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-timeout@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-web@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2)))
       '@deepseek-ai/dsh-web-search-deepseek': 0.1.2-rc.1(patch_hash=8fc8fbf566dc108b9d2526ce27516a815102ac9599c28f14ecb909aef021e248)(804d62b560bafed014909c63aed6f81a)
       '@deepseek-ai/dsh-workflow-worker-thread': 0.1.2-rc.1(1723bf50f1484c7d31b1de4b6b6ea1e1)
     transitivePeerDependencies:
@@ -6586,7 +6586,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@deepseek-ai/dsh-web-fetch-http@0.1.2-rc.1(patch_hash=dfca34998ca1c2b3676f8a98fc5a02cc8590b1247d05a936cc7b2189ec0c6548)(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-timeout@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-web@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2)))':
+  '@deepseek-ai/dsh-web-fetch-http@0.1.2-rc.1(patch_hash=ccd9c880b7bc79b388925ac30be3f7e722d82e571ce13dfb2c444eaf992325d0)(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-timeout@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-web@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-timeout': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)

--- a/apps/dsh-edge/standalone/scripts/bundle-standalone.mjs
+++ b/apps/dsh-edge/standalone/scripts/bundle-standalone.mjs
@@ -11,7 +11,7 @@ import edgePackage from '../../package.json' with { type: 'json' }
 import { requireGzipBudget } from '../../scripts/bundle-size.mjs'
 import { renderParsedSourceModeWranglerConfig } from '../../scripts/wrangler-config-core.mjs'
 
-const DIRECT_GZIP_BUDGET_BYTES = 1032 * 1024
+const DIRECT_GZIP_BUDGET_BYTES = 900 * 1024
 const standaloneDirectory = fileURLToPath(new URL('..', import.meta.url))
 const appDirectory = resolve(standaloneDirectory, '..')
 const standaloneRequire = createRequire(join(standaloneDirectory, 'package.json'))

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,7 +12,7 @@ patchedDependencies:
   '@deepseek-ai/dsh-message-feedback@0.1.2-rc.1': 74241acf25fcdc79a248d1510d3d2427befba3f0bf57da4ffab768065f5a8cd1
   '@deepseek-ai/dsh-session-persistence@0.1.2-rc.1': 1fc50721353748d4c7e0da2bb0ebf5eeecb5aa76aaa2d15f131e5ebbdbfcd633
   '@deepseek-ai/dsh-tool-web@0.1.2-rc.1': 359115e326d2ab890bc6c25e3e7672cda55ea87a74af80369a8cb411b7ae306c
-  '@deepseek-ai/dsh-web-fetch-http@0.1.2-rc.1': dfca34998ca1c2b3676f8a98fc5a02cc8590b1247d05a936cc7b2189ec0c6548
+  '@deepseek-ai/dsh-web-fetch-http@0.1.2-rc.1': ccd9c880b7bc79b388925ac30be3f7e722d82e571ce13dfb2c444eaf992325d0
   '@deepseek-ai/dsh-web-search-deepseek@0.1.2-rc.1': 8fc8fbf566dc108b9d2526ce27516a815102ac9599c28f14ecb909aef021e248
   '@deepseek-ai/dsh-workspace@0.1.2-rc.1': 1610ae8e37027b67c3804cc5278cb4cdbabef5d8d0a439d71ddd1da23bae76e6
 
@@ -224,7 +224,7 @@ importers:
         version: 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2))
       '@deepseek-ai/dsh-web-fetch-http':
         specifier: 0.1.2-rc.1
-        version: 0.1.2-rc.1(patch_hash=dfca34998ca1c2b3676f8a98fc5a02cc8590b1247d05a936cc7b2189ec0c6548)(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-timeout@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-web@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2)))
+        version: 0.1.2-rc.1(patch_hash=ccd9c880b7bc79b388925ac30be3f7e722d82e571ce13dfb2c444eaf992325d0)(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-timeout@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-web@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2)))
       '@deepseek-ai/dsh-web-search-deepseek':
         specifier: 0.1.2-rc.1
         version: 0.1.2-rc.1(patch_hash=8fc8fbf566dc108b9d2526ce27516a815102ac9599c28f14ecb909aef021e248)(804d62b560bafed014909c63aed6f81a)
@@ -4244,7 +4244,7 @@ snapshots:
     dependencies:
       '@deepseek-ai/cordis': 4.0.2(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
 
-  '@deepseek-ai/dsh-web-fetch-http@0.1.2-rc.1(patch_hash=dfca34998ca1c2b3676f8a98fc5a02cc8590b1247d05a936cc7b2189ec0c6548)(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-timeout@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-web@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2)))':
+  '@deepseek-ai/dsh-web-fetch-http@0.1.2-rc.1(patch_hash=ccd9c880b7bc79b388925ac30be3f7e722d82e571ce13dfb2c444eaf992325d0)(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-timeout@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2))(@deepseek-ai/dsh-web@0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)(@deepseek-ai/dsh-llm@0.1.2-rc.1(patch_hash=332e469d0d07af2797fb62bb73c3ea3ea356582bac3714c22dce93369fcc96da)(@deepseek-ai/cordis@4.0.2)))':
     dependencies:
       '@deepseek-ai/cordis': 4.0.2(@deepseek-ai/cordis-plugin-include@1.0.6)(@deepseek-ai/cordis-plugin-loader@1.0.2)
       '@deepseek-ai/dsh-timeout': 0.1.2-rc.1(@deepseek-ai/cordis@4.0.2)


### PR DESCRIPTION
## Summary

- Extend the `dsh-web-fetch-http` patch: replace the DNS-pinned undici transport with the Workers global fetch. The platform's `global_fetch_strictly_public` setting blocks private destinations after DNS resolution, which is the same rebinding attack the pinned transport defends against, and workerd cannot run undici Agent or `node:dns` lookups anyway — the success path was unverified dead weight.
- Keep per-hop lexical validation (`assertPublicFetchTarget`) and IP-literal public checks; add the RFC 6761 `.localhost` TLD to the local-hostname blocklist, which the removed DNS layer previously caught (covered by the existing `service.localhost` unit assertion).
- Direct Worker bundle drops 1031 → 856 KiB gzip; restore the budget to 900 KiB (43 KiB headroom).
- Update the patch audit rationale/removal condition accordingly.

## Validation

- Unit 279, snapshot 4/4, session integration in both Worker modes, standalone verify (9 patches, determinism, both modes), `git diff --check`.
- Gzip budget: 876442/921600 bytes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)