### PR TITLE
refactor: dispatch typert fallback directly and drop no-op waitUntil

### DIFF
--- a/apps/dsh-edge/src/edge-api-dispatch.ts
+++ b/apps/dsh-edge/src/edge-api-dispatch.ts
@@ -38,6 +38,23 @@ function errorResponse(rpcId: RpcId, error: RpcError): Response {
   return Response.json({ type: 'server-response', rpcId, result: { ok: false, error } })
 }
 
+/**
+ * Invoke one Edge API handler directly, without the HTTP envelope. Returns
+ * undefined when no handler serves the `<namespace>.<method>` key so callers
+ * can surface their own routing failure.
+ */
+export async function callEdgeApi(
+  api: EdgeApi,
+  key: string,
+  rpcId: RpcId,
+  payload: unknown,
+  signal: AbortSignal,
+): Promise<{ rpcId: unknown; result: unknown } | undefined> {
+  const handler = resolve(api, key)
+  if (handler === undefined) return undefined
+  return await handler({ rpcId, payload } as never, signal)
+}
+
 export async function dispatchEdgeApi(api: EdgeApi, request: Request): Promise<Response> {
   const url = new URL(request.url)
   const path = url.pathname
@@ -51,8 +68,7 @@ export async function dispatchEdgeApi(api: EdgeApi, request: Request): Promise<R
   }
 
   const method = path.slice('/api/'.length)
-  const handler = resolve(api, method)
-  if (handler === undefined) return new Response('not found', { status: 404 })
+  if (resolve(api, method) === undefined) return new Response('not found', { status: 404 })
 
   let body: Record<string, unknown>
   try { body = await request.json() as Record<string, unknown> } catch {
@@ -63,7 +79,8 @@ export async function dispatchEdgeApi(api: EdgeApi, request: Request): Promise<R
   const payload = body.payload ?? {}
 
   try {
-    const result = await handler({ rpcId, payload } as never, request.signal)
+    const result = await callEdgeApi(api, method, rpcId, payload, request.signal)
+    if (result === undefined) return new Response('not found', { status: 404 })
     return Response.json({ type: 'server-response', rpcId: result.rpcId, result: result.result })
   } catch (error) {
     return errorResponse(rpcId, { code: 'internal', message: String(error), details: {} })

--- a/apps/dsh-edge/src/edge-rpc-types.ts
+++ b/apps/dsh-edge/src/edge-rpc-types.ts
@@ -74,11 +74,6 @@ export interface HistoryEntry {
   view?: unknown
 }
 
-export interface SessionProjectionsBlock {
-  asOfSeq: number
-  values: Record<string, unknown>
-}
-
 // ---------------------------------------------------------------------------
 // Edge API payload types — one per RPC method in createEdgeApi()
 // ---------------------------------------------------------------------------

--- a/apps/dsh-edge/src/instance.ts
+++ b/apps/dsh-edge/src/instance.ts
@@ -674,15 +674,24 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
       const flatArgs = keys.length === 1 && keys[0] === 'request'
         ? args.request as Record<string, unknown>
         : args
-      const called = await callEdgeApi(
-        this.api,
-        `${ns}.${method}`,
-        RpcId(rpcId),
-        flatArgs,
-        request.signal,
-      )
-      if (called === undefined) return new Response('not found', { status: 404 })
-      return Response.json({ type: 'server-response', rpcId: called.rpcId, result: called.result })
+      try {
+        const called = await callEdgeApi(
+          this.api,
+          `${ns}.${method}`,
+          RpcId(rpcId),
+          flatArgs,
+          request.signal,
+        )
+        if (called === undefined) return new Response('not found', { status: 404 })
+        return Response.json({ type: 'server-response', rpcId: called.rpcId, result: called.result })
+      } catch (error) {
+        // Same error envelope the HTTP dispatcher produces, so handler
+        // rejections stay correlated server-responses on the direct path.
+        return Response.json({ type: 'server-response', rpcId, result: {
+          ok: false,
+          error: { code: 'internal', message: String(error), details: {} },
+        } })
+      }
     }
     // The Edge owns the turn lifecycle: agents open per turn and dispose when
     // it ends, matching Durable Object eviction, while the upstream controller

--- a/apps/dsh-edge/src/instance.ts
+++ b/apps/dsh-edge/src/instance.ts
@@ -21,7 +21,7 @@ import {
   type QueuedInboxItem,
   type ServerRequest,
 } from './edge-rpc-types.ts'
-import { dispatchEdgeApi } from './edge-api-dispatch.ts'
+import { callEdgeApi, dispatchEdgeApi } from './edge-api-dispatch.ts'
 import { freezeMessage, type MessageId, type UserMessage } from '@deepseek-ai/dsh-llm'
 import type { ContentBlock } from '@deepseek-ai/dsh-llm/types'
 import { SessionId, type SessionEvent } from '@deepseek-ai/dsh-session'
@@ -271,7 +271,6 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
         }
         queue.push({ key, value, seq })
       },
-      waitUntil: promise => this.ctx.waitUntil(promise),
     },
   )
   private readonly model = resolveEdgeModel(this.env.DEEPSEEK_MODEL)
@@ -670,22 +669,26 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
     const args = payload?.args as Record<string, unknown> | undefined ?? {}
     const ns = match[1]!
     const method = match[2]!
-    const edgeDispatch = () => {
+    const edgeDispatch = async () => {
       const keys = Object.keys(args)
       const flatArgs = keys.length === 1 && keys[0] === 'request'
         ? args.request as Record<string, unknown>
         : args
-      const edgeBody = { ...body, payload: flatArgs }
-      const edgePath = `/api/${ns}.${method}`
-      return this.apiFetch(new Request(new URL(edgePath, request.url).href, {
-        method: 'POST',
-        headers: request.headers,
-        body: JSON.stringify(edgeBody),
-      }))
+      const called = await callEdgeApi(
+        this.api,
+        `${ns}.${method}`,
+        RpcId(rpcId),
+        flatArgs,
+        request.signal,
+      )
+      if (called === undefined) return new Response('not found', { status: 404 })
+      return Response.json({ type: 'server-response', rpcId: called.rpcId, result: called.result })
     }
-    // The Edge owns the turn lifecycle (Computer shell binding and DO
-    // waitUntil keep-alive), so prompt admission and cancellation stay on the
-    // Edge implementation until that lifecycle moves into agent hooks.
+    // The Edge owns the turn lifecycle: agents open per turn and dispose when
+    // it ends, matching Durable Object eviction, while the upstream controller
+    // assumes resident agents it can resume and keep. Prompt admission and
+    // cancellation stay on the Edge implementation until that lifecycle
+    // reconciliation lands.
     if (ns === 'session' && (method === 'prompt' || method === 'cancel')) return edgeDispatch()
     const gateway = this.sessions.typertGateway()
     if (gateway === undefined) return edgeDispatch()
@@ -947,7 +950,9 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
         console.error('dsh-edge turn transport failed.', error)
       },
     )
-    this.ctx.waitUntil(completion.catch(() => undefined))
+    // Durable Objects stay active while the turn's pending work runs;
+    // DurableObjectState.waitUntil is a no-op and is deliberately not used.
+    void completion.catch(() => undefined)
 
     return new Response(stream, {
       status: 200,
@@ -1009,9 +1014,9 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
           ? {}
           : { clientTimeZone: input.clientTimeZone },
       })
-      this.ctx.waitUntil(running.catch((error: unknown) => {
+      void running.catch((error: unknown) => {
         console.error('dsh-edge upstream protocol turn failed.', error)
-      }))
+      })
       await claimed.turn.admissionReady
       if (!claimed.turn.wasAdmitted) await running
       return

--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -115,7 +115,6 @@ interface EdgeSessionStoreConfig {
   streamIdleTimeoutMs?: string
   onLateSessionEvent?: (sessionId: SessionId, event: SessionEvent) => void
   onProjectionChanged?: (sessionId: SessionId, key: string, value: unknown, seq: number) => void
-  waitUntil?: (promise: Promise<unknown>) => void
 }
 const MAX_FORK_STORED_BYTES = 8 * 1_024 * 1_024
 const MAX_SEARCH_SESSIONS = 32
@@ -425,17 +424,17 @@ export class EdgeSessionStore {
     )
     if (config.onLateSessionEvent !== undefined) {
       const callback = config.onLateSessionEvent
-      const keepAlive = config.waitUntil
       this.context.on('session/event', (session, event) => {
         const agent = this.context.agents.get(session.id)
         if (agent?.session === session && this.turnPublishedAgents.has(agent)) return
         if (event.type === 'session/title' && event.data.source.kind === 'user') return
-        const delivery = this.context.sessions.flush(session).then(() => {
+        // The flush promise is pending work, which keeps the Durable Object
+        // active by itself; DurableObjectState.waitUntil would be a no-op.
+        void this.context.sessions.flush(session).then(() => {
           callback(session.id, event)
         }).catch((error: unknown) => {
           console.error('dsh-edge: failed to flush late session event.', error)
         })
-        keepAlive?.(delivery)
       })
     }
     if (config.onProjectionChanged !== undefined) {

--- a/apps/dsh-edge/tests/session.integration.mjs
+++ b/apps/dsh-edge/tests/session.integration.mjs
@@ -330,6 +330,14 @@ try {
     ok: true,
     value: { items: [feedbackItem] },
   })
+  // A rejecting Edge handler on the direct fallback path must still produce a
+  // correlated server-response RPC error envelope, not an HTTP-level failure.
+  const malformedPrompt = await typertRpc('session', 'prompt', {
+    request: { sessionId },
+  })
+  assert.equal(malformedPrompt.body.type, 'server-response')
+  assert.equal(malformedPrompt.body.result.ok, false, JSON.stringify(malformedPrompt.body))
+  assert.equal(typeof malformedPrompt.body.result.error.code, 'string')
 
   const secondEvents = await turn(sessionId, 'history check')
   assert.equal(assistantText(secondEvents), 'history-ok')


### PR DESCRIPTION
## Summary

Phase-2 follow-up to #125, scoped by what reconnaissance actually found:

- **Kill the fake HTTP round trip.** The typert endpoint's fallback (session/prompt + session/cancel carve-out, gateway-unavailable, and unserved-endpoint paths) serialized a synthetic `Request` and re-parsed the legacy envelope via `apiFetch` on every call. New `callEdgeApi` invokes the handler directly; the legacy envelope now exists only on the real HTTP surface (`POST /api/<ns>.<method>`), which stays for integration tests and external consumers.
- **Remove no-op keep-alive machinery.** Per [Durable Object State docs](https://developers.cloudflare.com/durable-objects/api/state/), `DurableObjectState.waitUntil` has no effect; DOs remain active while they have ongoing work or pending I/O — which every turn promise and late-event flush already is. Removed both `ctx.waitUntil` wrappers and the `session-store` `waitUntil` config seam (`.catch` error logging retained).
- **Correct the carve-out comment.** The real reason prompt/cancel stay Edge-owned is the lifecycle mismatch: Edge opens an agent per turn and disposes it, matching DO eviction; the upstream controller resumes and retains resident agents. `waitUntil` was never the constraint.
- Delete the dead `SessionProjectionsBlock` type.

Explicitly **not** in scope (recon findings): `edge-rpc-types.ts` / `edge-api-dispatch.ts` are not dead code — they type and serve the Edge's own HTTP RPC API (85 integration call sites). Retiring that surface is a separate product decision.

## Validation

- Unit 279, snapshot 4/4, session integration both Worker modes, standalone verify, `git diff --check`.
- Gzip 878429/921600 (unchanged — the removed layer was cheap in bytes, expensive in indirection).

🤖 Generated with [Claude Code](https://claude.com/claude-code)