### PR TITLE
fix: implement the per-record KV unit contract in the Durable Object backend

### DIFF
--- a/apps/dsh-edge/src/do-storage-backend.ts
+++ b/apps/dsh-edge/src/do-storage-backend.ts
@@ -11,12 +11,48 @@ import { StorageError } from '@deepseek-ai/dsh-storage'
 /**
  * Key schema (all prefixed to avoid collisions with other DO KV usage):
  *
- *   dsh-kv:{unitName}:__version__           → number
- *   dsh-kv:{unitName}:__global__            → unknown (JSON value)
- *   dsh-kv:{unitName}:{table}:{key}         → unknown (JSON value)
+ *   dsh-kv:{unitName}:__version__                       → number
+ *   dsh-kv:{unitName}:__global__                        → value | StampedDocument
+ *   dsh-kv:{unitName}:{table}:{key}                     → value | StampedDocument
+ *   dsh-kv:{unitName}:__backup__:{table}:{key}:{stamp}  → BackupDocument
+ *
+ * Layout semantics follow the upstream `KvUnitDescriptor` contract:
+ *
+ * - `single` (the default): the unit stamp is exact. A stored stamp that
+ *   differs from the descriptor version rejects the open with
+ *   `version-mismatch`; values are stored bare.
+ * - `per-record`: every document carries its own version stamp
+ *   ({@link StampedDocument}); reads accept the descriptor version plus its
+ *   `compatibleVersions`, and a document stamped with any other version is
+ *   FOREIGN and reads as absent — never deleted, never a rejected open. Bare
+ *   documents predate the stamped format; they inherit the unit stamp
+ *   (`__version__`), which is therefore never rewritten once present, so a
+ *   later version bump still classifies them by the version that wrote them.
+ *   Writes always stamp the descriptor version, so a medium upgrades one
+ *   record at a time as the owner rewrites it — no startup scan.
  */
 
 const KV_PREFIX = 'dsh-kv:'
+const DOCUMENT_KIND = 'dsh-kv-record'
+const BACKUP_KIND = 'dsh-kv-backup'
+const BACKUP_TABLE = '__backup__'
+/** Per-record keys become key segments; the upstream contract rejects anything else on write. */
+const SAFE_KEY_RE = /^[a-zA-Z0-9_-]+$/
+
+/** One `per-record` document: the version that wrote it plus the value. */
+interface StampedDocument {
+  readonly $kind: typeof DOCUMENT_KIND
+  readonly version: number
+  readonly record: unknown
+}
+
+/** A document moved aside by {@link KvUnit.backupRecord}, retained for inspection. */
+interface BackupDocument {
+  readonly $kind: typeof BACKUP_KIND
+  readonly version: number | undefined
+  readonly record: unknown
+  readonly backedUpAt: string
+}
 
 function versionKey(unit: string): string {
   return `${KV_PREFIX}${unit}:__version__`
@@ -30,10 +66,37 @@ function recordKey(unit: string, table: string, key: string): string {
   return `${KV_PREFIX}${unit}:${table}:${key}`
 }
 
+function backupKey(unit: string, table: string, key: string, stamp: string): string {
+  return `${KV_PREFIX}${unit}:${BACKUP_TABLE}:${table}:${key}:${stamp}`
+}
+
 function unitPrefix(unit: string): string {
   return `${KV_PREFIX}${unit}:`
 }
 
+function isStampedDocument(value: unknown): value is StampedDocument {
+  return typeof value === 'object'
+    && value !== null
+    && (value as { $kind?: unknown }).$kind === DOCUMENT_KIND
+    && typeof (value as { version?: unknown }).version === 'number'
+}
+
+function stampDocument(version: number, record: unknown): StampedDocument {
+  return { $kind: DOCUMENT_KIND, version, record }
+}
+
+/** UTC `YYYYMMDDHHmm` suffix for backed-up documents, matching the upstream json backend. */
+function backupStamp(now: Date): string {
+  const pad = (value: number): string => String(value).padStart(2, '0')
+  return `${String(now.getUTCFullYear())}${pad(now.getUTCMonth() + 1)}${pad(now.getUTCDate())}`
+    + `${pad(now.getUTCHours())}${pad(now.getUTCMinutes())}`
+}
+
+function assertSafeKey(unit: string, key: string): void {
+  if (!SAFE_KEY_RE.test(key)) {
+    throw new Error(`unit '${unit}': per-record key '${key}' is not key-safe (must match ${SAFE_KEY_RE})`)
+  }
+}
 
 /**
  * One opened KV unit over Durable Object storage. Reads are list-scans;
@@ -42,11 +105,48 @@ function unitPrefix(unit: string): string {
  */
 class DurableObjectKvUnit implements KvUnit {
   private closed = false
+  private readonly perRecord: boolean
+  /** Version stamps this unit reads as its own (per-record layout only). */
+  private readonly acceptedVersions: ReadonlySet<number>
+
+  /**
+   * Move one record's document out of the readable set. Only offered for the
+   * `per-record` layout: a `single`-layout unit omits the member so the domain
+   * layer takes its reject-loud path, per the upstream contract.
+   */
+  backupRecord?: (table: string, key: string) => Promise<string>
 
   constructor(
     private readonly storage: DurableObjectStorage,
     private readonly descriptor: KvUnitDescriptor,
-  ) {}
+    /** The stamp bare (pre-stamped-format) documents inherit. */
+    private readonly legacyVersion: number,
+  ) {
+    this.perRecord = descriptor.layout === 'per-record'
+    this.acceptedVersions = new Set([descriptor.version, ...descriptor.compatibleVersions ?? []])
+    if (this.perRecord) {
+      this.backupRecord = async (table, key) => {
+        this.assertOpen()
+        this.assertTable(table)
+        const active = recordKey(this.descriptor.name, table, key)
+        const stored = await this.storage.get(active)
+        const moved = backupKey(this.descriptor.name, table, key, backupStamp(new Date()))
+        if (stored !== undefined) {
+          const backup: BackupDocument = {
+            $kind: BACKUP_KIND,
+            version: isStampedDocument(stored) ? stored.version : this.legacyVersion,
+            record: isStampedDocument(stored) ? stored.record : stored,
+            backedUpAt: new Date().toISOString(),
+          }
+          // Copy first, then delete: a crash between the two leaves the record
+          // readable and re-backed-up on the next open, never lost.
+          await this.storage.put(moved, backup)
+          await this.storage.delete(active)
+        }
+        return moved
+      }
+    }
+  }
 
   async loadAll(): Promise<{
     tables: Record<string, Record<string, unknown>>
@@ -64,7 +164,8 @@ class DurableObjectKvUnit implements KvUnit {
     for (const [key, value] of entries) {
       if (key === versionKey(this.descriptor.name)) continue
       if (key === gk) {
-        global = value
+        const read = this.readDocument(value)
+        if (read.present) global = read.record
         continue
       }
       // Parse record keys: dsh-kv:{unit}:{table}:{recordKey}
@@ -74,18 +175,20 @@ class DurableObjectKvUnit implements KvUnit {
       if (separatorIndex < 0) continue
       const tableName = suffix.slice(0, separatorIndex)
       const recordId = suffix.slice(separatorIndex + 1)
-      // Skip meta keys
-      if (tableName === '__version__' || tableName === '__global__') continue
-      if (tables[tableName] !== undefined) {
-        tables[tableName]![recordId] = value
-      }
+      // Skip meta keys and backed-up documents (never part of the readable set).
+      if (tableName === '__version__' || tableName === '__global__' || tableName === BACKUP_TABLE) continue
+      const table = tables[tableName]
+      if (table === undefined) continue
+      const read = this.readDocument(value)
+      if (read.present) table[recordId] = read.record
     }
     return { tables, global }
   }
 
   async putRecord(table: string, key: string, value: unknown): Promise<void> {
     this.assertOpen()
-    await this.storage.put(recordKey(this.descriptor.name, table, key), value)
+    if (this.perRecord) assertSafeKey(this.descriptor.name, key)
+    await this.storage.put(recordKey(this.descriptor.name, table, key), this.writeDocument(value))
   }
 
   async deleteRecord(table: string, key: string): Promise<void> {
@@ -95,11 +198,38 @@ class DurableObjectKvUnit implements KvUnit {
 
   async setGlobal(value: unknown): Promise<void> {
     this.assertOpen()
-    await this.storage.put(globalKey(this.descriptor.name), value)
+    await this.storage.put(globalKey(this.descriptor.name), this.writeDocument(value))
   }
 
   async close(): Promise<void> {
     this.closed = true
+  }
+
+  /**
+   * Classify one stored value. In the `single` layout every value is bare and
+   * current. In the `per-record` layout a stamped document is readable only
+   * when its stamp is accepted; a bare document inherits the unit stamp.
+   */
+  private readDocument(value: unknown): { present: true; record: unknown } | { present: false } {
+    if (!this.perRecord) return { present: true, record: value }
+    if (isStampedDocument(value)) {
+      return this.acceptedVersions.has(value.version)
+        ? { present: true, record: value.record }
+        : { present: false }
+    }
+    return this.acceptedVersions.has(this.legacyVersion)
+      ? { present: true, record: value }
+      : { present: false }
+  }
+
+  private writeDocument(value: unknown): unknown {
+    return this.perRecord ? stampDocument(this.descriptor.version, value) : value
+  }
+
+  private assertTable(table: string): void {
+    if (!this.descriptor.tables.includes(table)) {
+      throw new Error(`unit '${this.descriptor.name}' does not declare table '${table}'`)
+    }
   }
 
   private assertOpen(): void {
@@ -126,27 +256,32 @@ export class DurableObjectStorageBackend implements StorageBackend {
           throw new Error(`unit '${descriptor.name}' is already open`)
         }
 
-        // Check version stamp on the medium
-        const storedVersion = await this.storage.get(
-          versionKey(descriptor.name),
-        )
-        if (storedVersion !== undefined) {
-          if (storedVersion !== descriptor.version) {
+        const storedVersion = await this.storage.get(versionKey(descriptor.name))
+        let legacyVersion = descriptor.version
+        if (typeof storedVersion === 'number') {
+          if (descriptor.layout === 'per-record') {
+            // The stamp records which version wrote the bare documents; keep it
+            // so a later bump still classifies them correctly, and never reject
+            // the open — foreign documents simply read as absent.
+            legacyVersion = storedVersion
+          } else if (storedVersion !== descriptor.version) {
             throw new StorageError(
               'version-mismatch',
               `unit '${descriptor.name}' medium version ${JSON.stringify(storedVersion)} does not match descriptor version ${descriptor.version}`,
             )
           }
+        } else if (storedVersion !== undefined) {
+          throw new StorageError(
+            'malformed-medium',
+            `unit '${descriptor.name}' medium version ${JSON.stringify(storedVersion)} is not a number`,
+          )
         } else {
           // First open: stamp the version
-          await this.storage.put(
-            versionKey(descriptor.name),
-            descriptor.version,
-          )
+          await this.storage.put(versionKey(descriptor.name), descriptor.version)
         }
 
         this.openUnits.add(descriptor.name)
-        const unit = new DurableObjectKvUnit(this.storage, descriptor)
+        const unit = new DurableObjectKvUnit(this.storage, descriptor, legacyVersion)
         const originalClose = unit.close.bind(unit)
         unit.close = async () => {
           this.openUnits.delete(descriptor.name)

--- a/apps/dsh-edge/tests/do-storage-backend.spec.ts
+++ b/apps/dsh-edge/tests/do-storage-backend.spec.ts
@@ -1,3 +1,5 @@
+import { SessionId } from '@deepseek-ai/dsh-session'
+import type { KvUnitDescriptor } from '@deepseek-ai/dsh-storage'
 import { describe, expect, it } from 'vitest'
 import { DurableObjectStorageBackend } from '../src/do-storage-backend.ts'
 
@@ -129,5 +131,185 @@ describe('migrateWorkspaceKeys', () => {
     expect(record.updatedAt).toBe(REAL_TS)
     expect(storage.store.has('dsh-edge:workspace-domain-state:v2')).toBe(false)
     expect(storage.store.has('dsh-edge:workspace-domain-workspaces:edge-workspace:v2')).toBe(false)
+  })
+})
+
+const PER_RECORD_V5: KvUnitDescriptor = {
+  name: 'projcache',
+  version: 5,
+  tables: ['sessions'],
+  hasGlobal: false,
+  layout: 'per-record',
+  compatibleVersions: [3, 4],
+}
+const SINGLE_V5: KvUnitDescriptor = {
+  name: 'projcache',
+  version: 5,
+  tables: ['sessions'],
+  hasGlobal: false,
+}
+const STAMP = 'dsh-kv:projcache:__version__'
+const REC = (id: string): string => `dsh-kv:projcache:sessions:${id}`
+const V3_RECORD = { identity: { createdAt: 1000, cwd: '/workspace' }, rows: {} }
+
+describe('DurableObjectStorageBackend kv unit contract', () => {
+  it('reads a v3 per-record medium under a v5 descriptor that lists 3 as compatible', async () => {
+    const storage = createMockStorage()
+    storage.store.set(STAMP, 3)
+    storage.store.set(REC('s-1'), V3_RECORD)
+    const unit = await new DurableObjectStorageBackend(storage).kv.open(PER_RECORD_V5)
+    const snapshot = await unit.loadAll()
+    expect(snapshot.tables.sessions).toEqual({ 's-1': V3_RECORD })
+    // The unit stamp still records which version wrote the bare documents.
+    expect(storage.store.get(STAMP)).toBe(3)
+  })
+
+  it('keeps single-layout units exact-version: a v3 medium rejects a v5 descriptor', async () => {
+    const storage = createMockStorage()
+    storage.store.set(STAMP, 3)
+    storage.store.set(REC('s-1'), V3_RECORD)
+    await expect(new DurableObjectStorageBackend(storage).kv.open(SINGLE_V5))
+      .rejects.toMatchObject({ code: 'version-mismatch' })
+  })
+
+  it('reads per-record documents outside the accepted set as absent without deleting them', async () => {
+    const storage = createMockStorage()
+    storage.store.set(STAMP, 2)
+    storage.store.set(REC('stale'), V3_RECORD)
+    const unit = await new DurableObjectStorageBackend(storage).kv.open(PER_RECORD_V5)
+    expect((await unit.loadAll()).tables.sessions).toEqual({})
+    expect(storage.store.get(REC('stale'))).toEqual(V3_RECORD)
+    expect(storage.store.get(STAMP)).toBe(2)
+  })
+
+  it('stamps rewritten records with the current version so mixed media read per document', async () => {
+    const storage = createMockStorage()
+    storage.store.set(STAMP, 3)
+    storage.store.set(REC('old'), V3_RECORD)
+    storage.store.set(REC('rewritten'), V3_RECORD)
+    const backend = new DurableObjectStorageBackend(storage)
+    const unit = await backend.kv.open(PER_RECORD_V5)
+    const current = { identity: { createdAt: 2000, cwd: '/workspace', isSeeded: false }, rows: {} }
+    await unit.putRecord('sessions', 'rewritten', current)
+    await unit.close()
+    expect(storage.store.get(REC('rewritten'))).toMatchObject({ version: 5, record: current })
+
+    const reopened = await backend.kv.open(PER_RECORD_V5)
+    expect((await reopened.loadAll()).tables.sessions).toEqual({ old: V3_RECORD, rewritten: current })
+    await reopened.close()
+
+    // A later bump that drops 3 from the accepted set keeps only the v5 document.
+    const v6 = { ...PER_RECORD_V5, version: 6, compatibleVersions: [5] }
+    const bumped = await backend.kv.open(v6)
+    expect((await bumped.loadAll()).tables.sessions).toEqual({ rewritten: current })
+    expect(storage.store.get(REC('old'))).toEqual(V3_RECORD)
+  })
+
+  it('moves a record aside on backupRecord and lets a later put recreate it', async () => {
+    const storage = createMockStorage()
+    storage.store.set(STAMP, 3)
+    storage.store.set(REC('broken'), { identity: 'not-an-object' })
+    storage.store.set(REC('healthy'), V3_RECORD)
+    const unit = await new DurableObjectStorageBackend(storage).kv.open(PER_RECORD_V5)
+    expect(typeof unit.backupRecord).toBe('function')
+    const moved = await unit.backupRecord!('sessions', 'broken')
+    expect(moved).toMatch(/^dsh-kv:projcache:__backup__:sessions:broken:\d{12}$/u)
+    expect(storage.store.get(REC('broken'))).toBeUndefined()
+    expect(storage.store.get(moved)).toMatchObject({
+      $kind: 'dsh-kv-backup',
+      version: 3,
+      record: { identity: 'not-an-object' },
+    })
+    expect((await unit.loadAll()).tables.sessions).toEqual({ healthy: V3_RECORD })
+    await unit.putRecord('sessions', 'broken', V3_RECORD)
+    expect((await unit.loadAll()).tables.sessions).toEqual({ healthy: V3_RECORD, broken: V3_RECORD })
+    // The backup document never re-enters the readable set.
+    expect(storage.store.has(moved)).toBe(true)
+  })
+
+  it('omits backupRecord for single-layout units so the domain layer rejects loudly', async () => {
+    const storage = createMockStorage()
+    const unit = await new DurableObjectStorageBackend(storage).kv.open(SINGLE_V5)
+    expect(typeof unit.backupRecord).toBe('undefined')
+    await unit.putRecord('sessions', 'opaque:key/with slashes', V3_RECORD)
+    expect(storage.store.get(REC('opaque:key/with slashes'))).toEqual(V3_RECORD)
+  })
+
+  it('rejects key-unsafe per-record writes but still reads and deletes legacy keys', async () => {
+    const storage = createMockStorage()
+    storage.store.set(STAMP, 3)
+    storage.store.set(REC('legacy:key'), V3_RECORD)
+    const unit = await new DurableObjectStorageBackend(storage).kv.open(PER_RECORD_V5)
+    await expect(unit.putRecord('sessions', 'bad/key', V3_RECORD)).rejects.toThrow(/not key-safe/u)
+    expect((await unit.loadAll()).tables.sessions).toEqual({ 'legacy:key': V3_RECORD })
+    await unit.deleteRecord('sessions', 'legacy:key')
+    expect((await unit.loadAll()).tables.sessions).toEqual({})
+  })
+
+  it('stamps the global slot in the per-record layout and reads a bare legacy global', async () => {
+    const storage = createMockStorage()
+    storage.store.set(STAMP, 3)
+    storage.store.set('dsh-kv:projcache:__global__', { cursor: 1 })
+    const descriptor = { ...PER_RECORD_V5, hasGlobal: true }
+    const unit = await new DurableObjectStorageBackend(storage).kv.open(descriptor)
+    expect((await unit.loadAll()).global).toEqual({ cursor: 1 })
+    await unit.setGlobal({ cursor: 2 })
+    expect(storage.store.get('dsh-kv:projcache:__global__')).toMatchObject({ version: 5, record: { cursor: 2 } })
+    expect((await unit.loadAll()).global).toEqual({ cursor: 2 })
+  })
+
+  it('rejects a non-numeric unit stamp as a malformed medium', async () => {
+    const storage = createMockStorage()
+    storage.store.set(STAMP, 'three')
+    await expect(new DurableObjectStorageBackend(storage).kv.open(PER_RECORD_V5))
+      .rejects.toMatchObject({ code: 'malformed-medium' })
+  })
+})
+
+describe('session_projcache over the Durable Object backend', () => {
+  async function openProjectionCache(storage: DurableObjectStorage) {
+    const { Context } = await import('@deepseek-ai/cordis')
+    const { default: Storage } = await import('@deepseek-ai/dsh-storage')
+    const StorageDomain = await import('@deepseek-ai/dsh-storage-domain')
+    const { projectionCacheDomainSpec } = await import('@deepseek-ai/dsh-session-projection-cache')
+    const ctx = new Context()
+    const errors: string[] = []
+    ctx.logger.error = (message: unknown) => { errors.push(String(message)) }
+    await ctx.plugin(Storage)
+    ctx.effect(() => {
+      const dispose = ctx.storage.backend.register('durable-object', new DurableObjectStorageBackend(storage))
+      ctx.provide('storage.backend.durable-object', true)
+      return () => { dispose() }
+    }, 'test: storage backend')
+    await ctx.plugin(StorageDomain, { backend: 'durable-object' })
+    const domain = await ctx.storageDomain.open(projectionCacheDomainSpec)
+    return { domain, errors, spec: projectionCacheDomainSpec }
+  }
+
+  it('boots a Harness 0.1.1-rc.2 (v3) cache medium and serves its records', async () => {
+    const storage = createMockStorage()
+    storage.store.set('dsh-kv:session_projcache:__version__', 3)
+    storage.store.set('dsh-kv:session_projcache:sessions:session-old', V3_RECORD)
+    const { domain, errors, spec } = await openProjectionCache(storage)
+    expect(spec.version).toBe(5)
+    expect(spec.compatibleVersions).toEqual([3, 4])
+    expect(domain.table('sessions').get(SessionId('session-old'))).toMatchObject({ identity: { createdAt: 1000 } })
+    expect(errors).toEqual([])
+    await domain.close()
+  })
+
+  it('backs up and skips a schema-invalid cache record instead of failing the boot', async () => {
+    const storage = createMockStorage()
+    storage.store.set('dsh-kv:session_projcache:__version__', 3)
+    storage.store.set('dsh-kv:session_projcache:sessions:good', V3_RECORD)
+    storage.store.set('dsh-kv:session_projcache:sessions:corrupt', { identity: { createdAt: 'yesterday' }, rows: {} })
+    const { domain, errors } = await openProjectionCache(storage)
+    expect(domain.table('sessions').get(SessionId('good'))).toBeDefined()
+    expect(domain.table('sessions').get(SessionId('corrupt'))).toBeUndefined()
+    expect(errors).toHaveLength(1)
+    expect(errors[0]).toMatch(/corrupt.*moved to 'dsh-kv:session_projcache:__backup__:sessions:corrupt:\d{12}'/u)
+    expect(storage.store.get('dsh-kv:session_projcache:sessions:corrupt')).toBeUndefined()
+    expect([...storage.store.keys()].some(key => key.startsWith('dsh-kv:session_projcache:__backup__:sessions:corrupt:'))).toBe(true)
+    await domain.close()
   })
 })

--- a/apps/dsh-edge/tests/fixtures/capture-released-projcache.mjs
+++ b/apps/dsh-edge/tests/fixtures/capture-released-projcache.mjs
@@ -1,0 +1,105 @@
+/**
+ * Capture the `session_projcache` KV medium exactly as a published dsh-edge
+ * release writes it, for the released-state upgrade fixture.
+ *
+ * Usage (from apps/dsh-edge, with the release unpacked via `npm pack dsh-edge@<version>`):
+ *
+ *   node tests/fixtures/capture-released-projcache.mjs <unpacked-package-dir> <output.json>
+ *
+ * Runs the release's own direct Worker artifact against the mock DeepSeek
+ * server, creates one session, completes one turn (which checkpoints the
+ * projection cache), then reads the `dsh-kv:session_projcache:` keys back
+ * through a dump-only Durable Object over the same persisted state. No
+ * candidate runtime code is involved, so the output is a faithful medium of
+ * that release's Harness baseline.
+ */
+
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+import { unstable_dev } from 'wrangler'
+import { writePrebuiltModeWranglerConfig } from '../../scripts/wrangler-config.mjs'
+import { startMockDeepSeek } from './mock-deepseek.mjs'
+
+const [releasedDirectory, output] = process.argv.slice(2)
+if (releasedDirectory === undefined || output === undefined) {
+  process.stderr.write('Usage: node tests/fixtures/capture-released-projcache.mjs <unpacked-package-dir> <output.json>\n')
+  process.exit(2)
+}
+const released = resolve(releasedDirectory)
+const persist = mkdtempSync(join(tmpdir(), 'dsh-edge-projcache-capture-'))
+const config = join(persist, 'wrangler-direct.json')
+await writePrebuiltModeWranglerConfig('direct', config, {
+  appDirectory: released,
+  sourceConfigPath: join(released, 'wrangler.jsonc'),
+})
+const mock = await startMockDeepSeek()
+const ACCESS_KEY = 'integration-owner-access-key-32-bytes'
+const devOptions = {
+  config,
+  env: '',
+  persistTo: persist,
+  logLevel: 'error',
+  experimental: { disableExperimentalWarning: true, showInteractiveDevSession: false, watch: false },
+}
+
+const worker = await unstable_dev(join(released, 'worker/direct/index.js'), {
+  ...devOptions,
+  vars: {
+    DEEPSEEK_API_KEY: 'integration-test-key',
+    DEEPSEEK_BASE_URL: mock.url,
+    DEEPSEEK_SEARCH_BASE_URL: `${mock.url}/anthropic/v1`,
+    DEEPSEEK_MAX_OUTPUT_TOKENS: '16384',
+    DEEPSEEK_MODEL: 'deepseek-v4-pro',
+    DEEPSEEK_REASONING_EFFORT: 'high',
+    DSH_EDGE_DEFAULT_COMMAND_TIMEOUT_MS: '180000',
+    DSH_EDGE_MAX_COMMAND_TIMEOUT_MS: '240000',
+    DSH_EDGE_ACCESS_KEY: ACCESS_KEY,
+  },
+})
+try {
+  const login = await fetch(`http://${worker.address}:${worker.port}/api/auth/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/x-www-form-urlencoded' },
+    body: new URLSearchParams({ accessKey: ACCESS_KEY }).toString(),
+    redirect: 'manual',
+  })
+  const cookie = login.headers.get('set-cookie')?.split(';', 1)[0]
+  if (login.status !== 303 || cookie === undefined) throw new Error(`owner login failed: ${login.status}`)
+  const request = (path, init = {}) => worker.fetch(`http://dsh-edge.test${path}`, {
+    ...init,
+    headers: { ...init.headers ?? {}, cookie },
+  })
+  const created = await request('/api/sessions', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ title: 'Captured released projection cache' }),
+  })
+  if (created.status !== 201) throw new Error(`session create failed: ${created.status}`)
+  const { session } = await created.json()
+  const turn = await request(`/api/sessions/${session.id}/turn`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ message: 'capture projection cache' }),
+  })
+  const events = await turn.text()
+  if (turn.status !== 200 || !events.includes('"type":"turn/end"')) {
+    throw new Error(`turn did not complete: ${turn.status}`)
+  }
+  // Let the post-turn checkpoint writes settle before the Worker stops.
+  await new Promise(resolve => setTimeout(resolve, 1_500))
+} finally {
+  await worker.stop()
+}
+
+const dump = await unstable_dev(new URL('./dump-projcache-worker.mjs', import.meta.url).pathname, devOptions)
+try {
+  const response = await dump.fetch('http://dsh-edge.test/api/dump')
+  if (response.status !== 200) throw new Error(`dump failed: ${response.status}`)
+  const { entries } = await response.json()
+  writeFileSync(output, `${JSON.stringify(entries, null, 2)}\n`)
+  process.stdout.write(`captured ${Object.keys(entries).length} session_projcache entries to ${output}\n`)
+} finally {
+  await dump.stop()
+  await mock.close()
+}

--- a/apps/dsh-edge/tests/fixtures/dsh-edge-0.1.3-workspace.json
+++ b/apps/dsh-edge/tests/fixtures/dsh-edge-0.1.3-workspace.json
@@ -17,13 +17,5 @@
     ],
     "createdAt": "1970-01-01T00:00:00.000Z",
     "updatedAt": "2026-08-18T00:01:00.000Z"
-  },
-  "dsh-kv:session_projcache:__version__": 3,
-  "dsh-kv:session_projcache:sessions:session-v0-1-3": {
-    "identity": {
-      "createdAt": 1000,
-      "cwd": "/workspace"
-    },
-    "rows": {}
   }
 }

--- a/apps/dsh-edge/tests/fixtures/dsh-edge-0.1.3-workspace.json
+++ b/apps/dsh-edge/tests/fixtures/dsh-edge-0.1.3-workspace.json
@@ -17,5 +17,13 @@
     ],
     "createdAt": "1970-01-01T00:00:00.000Z",
     "updatedAt": "2026-08-18T00:01:00.000Z"
+  },
+  "dsh-kv:session_projcache:__version__": 3,
+  "dsh-kv:session_projcache:sessions:session-v0-1-3": {
+    "identity": {
+      "createdAt": 1000,
+      "cwd": "/workspace"
+    },
+    "rows": {}
   }
 }

--- a/apps/dsh-edge/tests/fixtures/dsh-edge-0.9.0-projcache.json
+++ b/apps/dsh-edge/tests/fixtures/dsh-edge-0.9.0-projcache.json
@@ -1,0 +1,62 @@
+{
+  "dsh-kv:session_projcache:__version__": 3,
+  "dsh-kv:session_projcache:sessions:e167a058-7c98-4dc5-82f5-bff3c319995f": {
+    "identity": {
+      "createdAt": 1788608633208,
+      "cwd": "/workspace"
+    },
+    "rows": {
+      "tokenUsage": {
+        "ver": 1,
+        "seq": 16,
+        "val": {
+          "totals": {
+            "uncachedInputTokens": 12,
+            "outputTokens": 2,
+            "cacheReadTokens": 0,
+            "cacheWriteTokens": 0
+          },
+          "last": {
+            "turn": 1,
+            "step": 1,
+            "buckets": {
+              "uncachedInputTokens": 12,
+              "outputTokens": 2,
+              "cacheReadTokens": 0,
+              "cacheWriteTokens": 0
+            }
+          }
+        }
+      },
+      "contextPressure": {
+        "ver": 4,
+        "seq": 16,
+        "val": {
+          "surfaceTokens": 26,
+          "contextWindow": 1000000,
+          "pressureTokens": 12,
+          "sampledSurfaceTokens": 14
+        }
+      },
+      "contextBreakdown": {
+        "ver": 2,
+        "seq": 16,
+        "val": {
+          "systemTokens": 653,
+          "toolsTokens": 1450,
+          "messageTokens": 26
+        }
+      },
+      "title": {
+        "ver": 1,
+        "seq": 16,
+        "val": "Captured on dsh-edge 0.9.0"
+      },
+      "goal": {
+        "ver": 4,
+        "seq": 16,
+        "val": null
+      }
+    }
+  }
+}

--- a/apps/dsh-edge/tests/fixtures/dump-projcache-worker.mjs
+++ b/apps/dsh-edge/tests/fixtures/dump-projcache-worker.mjs
@@ -1,0 +1,17 @@
+import { DurableObject } from 'cloudflare:workers'
+
+const OWNER_INSTANCE = 'owner'
+
+export default {
+  fetch(request, env) {
+    return env.DSH_EDGE_INSTANCE.getByName(OWNER_INSTANCE).fetch(request)
+  },
+}
+
+/** Read the projection-cache KV medium a released dsh-edge wrote, without importing any candidate runtime code. */
+export class DshEdgeInstance extends DurableObject {
+  async fetch() {
+    const entries = await this.ctx.storage.list({ prefix: 'dsh-kv:session_projcache:' })
+    return Response.json({ entries: Object.fromEntries(entries) })
+  }
+}

--- a/apps/dsh-edge/tests/session.integration.mjs
+++ b/apps/dsh-edge/tests/session.integration.mjs
@@ -1383,10 +1383,21 @@ async function seedReleasedState() {
         readFileSync(new URL('./fixtures/dsh-edge-0.1.3-vfs.sql', import.meta.url), 'utf8'),
         readFileSync(new URL('./fixtures/dsh-edge-0.1.3-session.sql', import.meta.url), 'utf8'),
       ],
-      entries: JSON.parse(readFileSync(
-        new URL('./fixtures/dsh-edge-0.1.3-workspace.json', import.meta.url),
-        'utf8',
-      )),
+      entries: {
+        ...JSON.parse(readFileSync(
+          new URL('./fixtures/dsh-edge-0.1.3-workspace.json', import.meta.url),
+          'utf8',
+        )),
+        // A session_projcache medium captured from the published dsh-edge 0.9.0
+        // (Harness 0.1.1-rc.2) Worker by tests/fixtures/capture-released-projcache.mjs:
+        // unit stamp 3 plus one bare checkpoint record. The candidate must open it
+        // through the projection cache's compatibleVersions instead of rejecting
+        // the boot with version-mismatch.
+        ...JSON.parse(readFileSync(
+          new URL('./fixtures/dsh-edge-0.9.0-projcache.json', import.meta.url),
+          'utf8',
+        )),
+      },
     }),
   })
   assert.equal(response.status, 200)


### PR DESCRIPTION
## Problem (release blocker for the 0.1.2-rc.1 baseline)

Upstream 0.1.2-alpha.5 fixed "upgrading from 0.1.1-rc.2 could prevent the app from starting or make session titles disappear" by moving `session_projcache` to version 5 with `layout: 'per-record'`, `compatibleVersions: [3, 4]`, optional lineage fields, and `invalidRecords: 'backup-and-skip'`. That fix relies on the storage backend implementing the `KvUnitDescriptor` layout contract.

Our Durable Object backend (`do-storage-backend.ts`) ignored `layout`, `compatibleVersions`, and `backupRecord`, and rejected any unit whose stamp differed from the descriptor. A home written by dsh-edge on 0.1.1-rc.2 (`session_projcache` stamped 3) therefore failed `storageDomain.open` with `version-mismatch` during `SessionProjectionCache` init, which blocks the whole plugin tree — the Worker cannot boot. Fresh installs never hit it, and the integration upgrade fixture dates from dsh-edge 0.1.3 (before the projection cache existed), so CI stayed green.

## Fix

Implement the upstream contract generically per layout (mirroring `@deepseek-ai/dsh-storage-json`'s per-record unit), no `session_projcache` special-casing:

- **`single`** (default): unchanged — exact stamp, `version-mismatch` otherwise, bare values, no `backupRecord` (so the domain layer keeps its reject-loud path).
- **`per-record`**: open never rejects on version. Writes store `{ $kind: 'dsh-kv-record', version, record }`; reads accept the descriptor version plus `compatibleVersions`; documents stamped outside that set read as **absent without deletion**; bare pre-stamp documents inherit the unit `__version__`, which is never rewritten once present, so a future 5→6 bump still classifies untouched v3 records correctly while rewritten records carry their own v5 stamp — no startup scan or migration. `backupRecord` copies the document to `dsh-kv:{unit}:__backup__:{table}:{key}:{YYYYMMDDHHmm}` then deletes the active key (copy-then-delete, never lossy) and returns that location for the domain's log line.
- Per-record `putRecord` enforces the contract's `[a-zA-Z0-9_-]+` key rule; reads and deletes stay lenient so legacy keys remain serviceable. A non-numeric unit stamp is reported as `malformed-medium`.

Nothing is deleted proactively; the projection cache is not cleared.

## Validation

- **Unit** (`do-storage-backend.spec.ts`, +11): compatible read of a v3 medium under v5, single-layout strictness, foreign-as-absent without deletion, mixed bare-v3/stamped-v5 media read per document and a later v6 (`compatibleVersions: [5]`) keeps only the v5 document, `backupRecord` moves aside and a later put recreates, `backupRecord` absent for single layout, key safety on write with lenient legacy read/delete, stamped global slot, malformed stamp.
- **Real domain end-to-end**: the actual `projectionCacheDomainSpec` (v5) opened through `Storage` + `StorageDomain` over this backend on a v3 medium serves the record with no errors; a schema-invalid record is backed up and skipped (logger message names the backup key) while its neighbour is served.
- **Integration**: the released-state fixture now seeds `dsh-kv:session_projcache:__version__ = 3` plus a bare v3 checkpoint for the fixture session. Verified negative: with the pre-fix backend this fixture fails the direct-mode integration with `version-mismatch`; with this PR both Worker modes pass.
- `pnpm run check` (314), snapshot 4/4, standalone verify, gzip 879074/921600.

🤖 Generated with [Claude Code](https://claude.com/claude-code)