### PR TITLE
release: dsh-edge 0.10.0-alpha.1

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.9.0",
+  "version": "0.10.0-alpha.1",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.10.0-alpha.1.i18n.yaml
+++ b/docs/releases/0.10.0-alpha.1.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.10.0-alpha.1.md: 4907a5e290c30d392125771cc32fea3f4872bd63
+0.10.0-alpha.1.zh.md: ec427c62f4a8838e0367ad45ca4505f02fd62cab

--- a/docs/releases/0.10.0-alpha.1.md
+++ b/docs/releases/0.10.0-alpha.1.md
@@ -1,0 +1,29 @@
+## dsh-edge 0.10.0-alpha.1
+
+Upstream baseline 0.1.2-rc.1: the Typert Remote protocol replaces the fetch RPC layer, with durable upgrade compatibility for existing homes. Alpha channel because the upstream baseline is itself a release candidate.
+
+### Changed
+
+- **Upstream baseline 0.1.2-rc.1**: every `@deepseek-ai/dsh-*` package moves from 0.1.1-rc.2 to 0.1.2-rc.1 (cordis 4.0.2). Upstream removed `dsh-host-apiproxy` and `dsh-client-runtime`; the Edge now serves the browser through the upstream session, settings, and workspace controllers over the Typert Remote protocol. Three Edge seams replace the former hand-written protocol layer: an `EdgeSessionQuery` service (bounded search over live sessions and recent summaries), a Durable Object backed default-model provider, and a forwarded-event source for the `$events` stream. Session prompt and cancel stay on the Edge turn lifecycle, which opens an agent per turn to match Durable Object eviction.
+- **Web fetch transport**: `web_fetch` requests go through the Workers global fetch instead of upstream's DNS-pinned undici transport, which cannot run on workerd. Per-hop public-target validation is unchanged and now also rejects the RFC 6761 `.localhost` TLD; the platform's `global_fetch_strictly_public` setting covers DNS rebinding. The direct Worker drops from 1031 KiB to about 859 KiB gzip and the budget returns to 900 KiB.
+- **Client plugin**: `dsh-edge-client-ui` targets `dsh-client-store`; the assembled client bundle grows to 39 plugins.
+
+### Fixed
+
+- **Upgrading from 0.9.0 and earlier**: the Durable Object storage backend implements the upstream per-record unit contract (`layout`, `compatibleVersions`, `backupRecord`). A `session_projcache` medium written by Harness 0.1.1-rc.2 (version 3) now opens under the version-5 descriptor instead of failing the boot with `version-mismatch`. Records outside the accepted versions read as absent without being deleted, schema-invalid cache records are backed up and skipped, and version stamps live in sidecar keys written atomically with each record, so stored values are never inspected. The released-state integration fixture now includes a projection cache captured from the published dsh-edge 0.9.0.
+- **Fork lineage persistence**: the inherited event count of a forked session is persisted and restored across cold loads.
+- **Remote stream ownership**: `/api/remote.mux` sockets schedule the same owner-token expiry as the other downlinks, and a socket restored from hibernation without stream state closes with code 1011 so the client reconnects instead of losing frames silently.
+- **Image prompts on the Typert route**: the entry Worker now gives `/api/session/prompt` and `/api/session/updateQueue` the same 10 MiB body budget as their legacy envelope forms, so prompts carrying inline image data (or more than 8 KiB of text) are no longer rejected with HTTP 413 before reaching the instance.
+- **Duplicate user message after sending**: the Edge prompt handler persists the client-minted `requestId` as the user message's `source.rpcId`, so the client reconciles its optimistic copy with the persisted message instead of showing it twice until reload.
+- **Workspace paths**: the Worker workspace patch canonicalizes `.`, `..`, and duplicate separators lexically, so traversal-style inputs no longer create alias workspaces.
+
+### Technical
+
+- The Typert endpoint's Edge fallback calls Edge API handlers directly instead of round-tripping a synthetic HTTP request; handler failures keep the correlated RPC error envelope.
+- `DurableObjectState.waitUntil` keep-alive threading is removed: it is a documented no-op, and pending turn work keeps the object active on its own.
+- Nine version-bound patches for 0.1.2-rc.1: `dsh-sandbox` and `dsh-llm-deepseek` were fixed upstream and removed, `dsh-llm` is retained, and `dsh-api-session-controller` is added to remove `node:fs` calls.
+
+### Dependencies
+
+- Runtime: `just-bash` 3.4.2, `@cloudflare/computer` 0.2.1, `wrangler` 4.129.0, `@cloudflare/workers-types` 5.20260904.1.
+- Removed `undici` from the Worker bundle.

--- a/docs/releases/0.10.0-alpha.1.zh.md
+++ b/docs/releases/0.10.0-alpha.1.zh.md
@@ -1,0 +1,29 @@
+## dsh-edge 0.10.0-alpha.1
+
+上游基线 0.1.2-rc.1：Typert Remote 协议取代 fetch RPC 层，并为既有实例提供持久化升级兼容。因上游基线本身仍是候选版本，本版本走 alpha 通道。
+
+### 变更
+
+- **上游基线 0.1.2-rc.1**：全部 `@deepseek-ai/dsh-*` 包从 0.1.1-rc.2 升至 0.1.2-rc.1（cordis 4.0.2）。上游移除了 `dsh-host-apiproxy` 和 `dsh-client-runtime`；Edge 现在通过上游的 session、settings、workspace 控制器以 Typert Remote 协议服务浏览器。三个 Edge 接缝取代了原先手写的协议层：`EdgeSessionQuery` 服务（对活跃会话与近期摘要的有界搜索）、基于 Durable Object 的默认模型提供者，以及 `$events` 流的事件转发源。会话 prompt 与 cancel 仍由 Edge 的 turn 生命周期承担，它按每轮开启 agent 以适配 Durable Object 回收。
+- **Web fetch 传输**：`web_fetch` 请求改走 Workers 全局 fetch，不再使用上游基于 undici 的 DNS 固定传输（后者无法在 workerd 上运行）。逐跳公网目标校验保持不变，并新增拒绝 RFC 6761 的 `.localhost` 顶级域；平台的 `global_fetch_strictly_public` 设置覆盖 DNS 重绑定。direct Worker 从 1031 KiB 降至约 859 KiB gzip，预算恢复为 900 KiB。
+- **客户端插件**：`dsh-edge-client-ui` 改用 `dsh-client-store`；装配后的客户端包增至 39 个插件。
+
+### 修复
+
+- **从 0.9.0 及更早版本升级**：Durable Object 存储后端实现了上游的 per-record 单元契约（`layout`、`compatibleVersions`、`backupRecord`）。由 Harness 0.1.1-rc.2 写出的 `session_projcache` 介质（版本 3）现在可在版本 5 的描述符下打开，不再以 `version-mismatch` 导致启动失败。版本不在接受集合内的记录视为不存在但不会被删除，schema 校验失败的缓存记录会先备份再跳过，版本戳存放在与记录原子写入的旁路键中，存储的值本身永不被检查。已发布状态集成夹具现包含从已发布的 dsh-edge 0.9.0 捕获的投影缓存。
+- **分叉血缘持久化**：分叉会话继承的事件计数会被持久化，并在冷加载后恢复。
+- **远程流所有权**：`/api/remote.mux` 套接字与其他下行链路一样调度所有者令牌过期，从休眠恢复但丢失流状态的套接字以 1011 关闭，让客户端重连而不是静默丢帧。
+- **Typert 路由上的图片 prompt**：入口 Worker 现在给 `/api/session/prompt` 和 `/api/session/updateQueue` 与旧信封路由相同的 10 MiB 请求体预算，带内联图片数据（或超过 8 KiB 文本）的 prompt 不再在到达实例之前被 HTTP 413 拒绝。
+- **发送后出现重复的用户消息**：Edge 的 prompt 处理器把客户端生成的 `requestId` 持久化为用户消息的 `source.rpcId`，客户端能将本地乐观显示的消息与持久化消息合并，不再重复显示到刷新为止。
+- **工作区路径**：Worker 的 workspace 补丁按词法规范化 `.`、`..` 和重复分隔符，遍历形式的输入不再创建别名工作区。
+
+### 技术
+
+- Typert 端点的 Edge 回退路径直接调用 Edge API 处理函数，不再往返一个合成的 HTTP 请求；处理函数失败时保留带关联 id 的 RPC 错误信封。
+- 移除 `DurableObjectState.waitUntil` 保活线：它是文档明确的 no-op，进行中的 turn 工作本身即可保持对象活跃。
+- 面向 0.1.2-rc.1 的 9 个版本绑定补丁：`dsh-sandbox` 与 `dsh-llm-deepseek` 已由上游修复而移除，`dsh-llm` 保留，新增 `dsh-api-session-controller` 以移除 `node:fs` 调用。
+
+### 依赖
+
+- 运行时：`just-bash` 3.4.2、`@cloudflare/computer` 0.2.1、`wrangler` 4.129.0、`@cloudflare/workers-types` 5.20260904.1。
+- 从 Worker 包中移除 `undici`。


### PR DESCRIPTION
## Release

Version bump to `0.10.0-alpha.1` (prerelease → npm `next` dist-tag, GitHub prerelease) with bilingual release notes and the doc-pair record. Contents since 0.9.0: #125 (upstream baseline 0.1.2-rc.1), #126 (web fetch via Workers fetch, undici dropped), #127 (dependency refresh), #128 (direct typert fallback, no-op waitUntil removed), #129 and #130 (Durable Object per-record storage contract — fixes boot failure when upgrading a 0.9.0 home).

Why a minor + alpha: the upstream baseline swap replaces the browser protocol layer and changes the storage medium format, and the upstream baseline is itself a release candidate.

Per AGENTS.md the version lives only in `apps/dsh-edge/package.json`; tests and snapshots derive it at runtime. After merge: pull main, `git tag dsh-edge-v0.10.0-alpha.1 && git push origin dsh-edge-v0.10.0-alpha.1`, which triggers `release-edge.yml`.

## Validation

- `pnpm run check` (315; doc pairs 37 consistent, legal files current), standalone verify, snapshot 4/4, dual-mode integration, gzip 879176/921600.
- `pnpm pack` → `pack:verify` with the alpha tarball name: both Worker modes start from the installed package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)