### PR TITLE
fix: give Typert prompt routes the turn body budget at the entry Worker

### DIFF
--- a/apps/dsh-edge/src/http.ts
+++ b/apps/dsh-edge/src/http.ts
@@ -13,6 +13,23 @@ export const MAX_MESSAGE_FEEDBACK_BODY_BYTES = 64 * 1_024
 export const MAX_TURN_BODY_BYTES = 10 * 1_024 * 1_024
 export const MAX_WORKSPACE_EXEC_BODY_BYTES = 131_072
 
+/**
+ * Body limit for one Durable Object API request, selected before the entry
+ * Worker forwards it. RPC routes are recognised in both wire forms — the
+ * legacy `/api/<namespace>.<method>` envelope and the Typert
+ * `/api/<namespace>/<method>` endpoint — so a prompt carrying inline image
+ * data gets the turn budget whichever path the client uses.
+ */
+export function instanceRequestBodyLimit(pathname: string): number {
+  if (pathname.endsWith('/turn') || pathname === '/api/skills') return MAX_TURN_BODY_BYTES
+  const route = /^\/api\/([a-zA-Z0-9_$-]+)[./]([a-zA-Z0-9_$-]+)$/.exec(pathname)
+  if (route === null) return MAX_SESSION_CREATE_BODY_BYTES
+  const key = `${route[1]}.${route[2]}`
+  if (key === 'session.prompt' || key === 'session.updateQueue') return MAX_TURN_BODY_BYTES
+  if (key === 'messageFeedback.put') return MAX_MESSAGE_FEEDBACK_BODY_BYTES
+  return MAX_SESSION_CREATE_BODY_BYTES
+}
+
 /** Invalid caller input with an explicit HTTP response status. */
 export class EdgeHttpError extends Error {
   constructor(readonly status: number, message: string) {

--- a/apps/dsh-edge/src/index.ts
+++ b/apps/dsh-edge/src/index.ts
@@ -10,14 +10,12 @@ import {
 } from './auth.ts'
 import {
   EdgeHttpError,
-  MAX_MESSAGE_FEEDBACK_BODY_BYTES,
-  MAX_SESSION_CREATE_BODY_BYTES,
-  MAX_TURN_BODY_BYTES,
   MAX_WORKSPACE_EXEC_BODY_BYTES,
   corsHeaders,
   discardUnreadRequestBody,
   errorResponse,
   jsonResponse,
+  instanceRequestBodyLimit,
   readBoundedBody,
   readBoundedText,
   readJsonObject,
@@ -166,15 +164,7 @@ async function requestForInstance(request: Request, ownerSessionExpiresAt: numbe
   headers.delete('x-dsh-edge-instance')
   headers.set(OWNER_SESSION_EXPIRY_HEADER, String(ownerSessionExpiresAt))
   if (request.body === null) return new Request(request, { headers })
-  const url = new URL(request.url)
-  const maxBytes = url.pathname === '/api/messageFeedback/put'
-    ? MAX_MESSAGE_FEEDBACK_BODY_BYTES
-    : url.pathname.endsWith('/turn')
-      || url.pathname === '/api/session.prompt'
-      || url.pathname === '/api/session.updateQueue'
-      || url.pathname === '/api/skills'
-      ? MAX_TURN_BODY_BYTES
-      : MAX_SESSION_CREATE_BODY_BYTES
+  const maxBytes = instanceRequestBodyLimit(new URL(request.url).pathname)
   const body = await readBoundedBody(
     request,
     maxBytes,

--- a/apps/dsh-edge/tests/http-body-limit.spec.ts
+++ b/apps/dsh-edge/tests/http-body-limit.spec.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_MESSAGE_FEEDBACK_BODY_BYTES,
+  MAX_SESSION_CREATE_BODY_BYTES,
+  MAX_TURN_BODY_BYTES,
+  instanceRequestBodyLimit,
+} from '../src/http.ts'
+
+describe('instanceRequestBodyLimit', () => {
+  it('gives prompts the turn budget on both the legacy and the Typert route form', () => {
+    expect(instanceRequestBodyLimit('/api/session.prompt')).toBe(MAX_TURN_BODY_BYTES)
+    expect(instanceRequestBodyLimit('/api/session/prompt')).toBe(MAX_TURN_BODY_BYTES)
+    expect(instanceRequestBodyLimit('/api/session.updateQueue')).toBe(MAX_TURN_BODY_BYTES)
+    expect(instanceRequestBodyLimit('/api/session/updateQueue')).toBe(MAX_TURN_BODY_BYTES)
+  })
+
+  it('keeps the dedicated budgets for turns, skills, and message feedback', () => {
+    expect(instanceRequestBodyLimit('/api/sessions/abc/turn')).toBe(MAX_TURN_BODY_BYTES)
+    expect(instanceRequestBodyLimit('/api/skills')).toBe(MAX_TURN_BODY_BYTES)
+    expect(instanceRequestBodyLimit('/api/messageFeedback/put')).toBe(MAX_MESSAGE_FEEDBACK_BODY_BYTES)
+    expect(instanceRequestBodyLimit('/api/messageFeedback.put')).toBe(MAX_MESSAGE_FEEDBACK_BODY_BYTES)
+  })
+
+  it('leaves every other route on the small default', () => {
+    expect(instanceRequestBodyLimit('/api/sessions')).toBe(MAX_SESSION_CREATE_BODY_BYTES)
+    expect(instanceRequestBodyLimit('/api/session/list')).toBe(MAX_SESSION_CREATE_BODY_BYTES)
+    expect(instanceRequestBodyLimit('/api/session.list')).toBe(MAX_SESSION_CREATE_BODY_BYTES)
+    expect(instanceRequestBodyLimit('/api/workspace/create')).toBe(MAX_SESSION_CREATE_BODY_BYTES)
+    expect(instanceRequestBodyLimit('/api/session/prompt/extra')).toBe(MAX_SESSION_CREATE_BODY_BYTES)
+  })
+})

--- a/apps/dsh-edge/tests/session.integration.mjs
+++ b/apps/dsh-edge/tests/session.integration.mjs
@@ -187,6 +187,21 @@ try {
   })
   assert.equal(oversizedSessionBody.response.status, 413)
 
+  // A prompt on the Typert route carries inline image data and long text, so
+  // the entry Worker must give it the turn budget rather than the 8 KiB
+  // session-create default; the request reaches the instance and fails on the
+  // unknown session inside the RPC envelope instead of a transport 413.
+  const largeTypertPrompt = await typertRpc('session', 'prompt', {
+    request: {
+      sessionId: 'not-real',
+      mode: 'queue',
+      content: [{ type: 'text', text: 'x'.repeat(64_000) }],
+    },
+  })
+  assert.equal(largeTypertPrompt.response.status, 200)
+  assert.equal(largeTypertPrompt.body.type, 'server-response')
+  assert.equal(largeTypertPrompt.body.result.ok, false)
+
   const malformedSessionId = await jsonRequest('/api/sessions/%/turn', {
     method: 'POST',
     headers: { 'content-type': 'application/json' },


### PR DESCRIPTION
## Problem

Found in local testing of the 0.10.0-alpha.1 candidate: attaching an image and sending fails with `client api: session/prompt failed: transport failure for /api/session/prompt: HTTP 413`.

`requestForInstance` in `src/index.ts` picks the body limit before forwarding to the Durable Object by exact legacy route names (`/api/session.prompt`, `/api/session.updateQueue`, `/api/messageFeedback/put`, `/api/skills`, `*/turn`). The 0.1.2-rc.1 client sends prompts on the Typert endpoint `/api/session/prompt`, which fell through to the 8 KiB session-create default, so every prompt with inline image data — or more than 8 KiB of text — was rejected at the entry Worker, before the instance's own image admission (3.5 MiB per image, 7 MiB per message) ever ran. The 0.9.0 client used the legacy route, which is why this only surfaced with the new baseline.

## Fix

- `instanceRequestBodyLimit(pathname)` in `http.ts` normalises `/api/<ns>.<method>` and `/api/<ns>/<method>` to one route key and applies the existing budgets: `session.prompt` / `session.updateQueue` / `/turn` / `/api/skills` → `MAX_TURN_BODY_BYTES` (10 MiB), `messageFeedback.put` → 64 KiB, everything else → 8 KiB. No limit values change.
- `index.ts` uses the helper.

## Validation

- Unit spec for the helper (both route forms, dedicated budgets, default routes, non-matching paths).
- Integration (both Worker modes): a 64 KB text prompt on `/api/session/prompt` for an unknown session now reaches the instance and fails inside the RPC envelope (`server-response`, `ok: false`) instead of a transport 413; the existing 413 assertions for oversized session-create bodies still pass.
- `pnpm run check` (318), standalone verify, snapshot 4/4, gzip 879258/921600.
- Manually verified locally: image prompt is accepted on the candidate build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)