### PR TITLE
fix: persist the client-minted requestId on Typert prompts

### DIFF
--- a/apps/dsh-edge/src/edge-api.ts
+++ b/apps/dsh-edge/src/edge-api.ts
@@ -48,6 +48,7 @@ import type {
   WorkspaceInsertSessionBeforePayload,
   WorkspaceRenamePayload,
 } from './edge-rpc-types.ts'
+import { RpcId } from './edge-rpc-types.ts'
 import {
   SettingsConflictError,
   type SettingsDescriptor,
@@ -363,7 +364,11 @@ export function createEdgeApi(runtime: EdgeApiRuntime) {
       },
 
       async prompt(request: RpcRequest<SessionPromptPayload>) {
-        const { sessionId, mode, content, clientTimeZone } = request.payload
+        const { sessionId, mode, content, clientTimeZone, requestId } = request.payload
+        // The user message carries the client-minted requestId when the Typert
+        // client supplies one, so its optimistic copy reconciles with the
+        // persisted message; the envelope rpcId stays the transport correlation.
+        const messageRpcId = typeof requestId === 'string' && requestId !== '' ? RpcId(requestId) : request.rpcId
         const zone = canonicalClientTimeZone(clientTimeZone)
         if (clientTimeZone !== undefined && zone === undefined) {
           return fail(request, {
@@ -420,7 +425,7 @@ export function createEdgeApi(runtime: EdgeApiRuntime) {
               sessionId,
               mode,
               content: durable,
-              rpcId: request.rpcId,
+              rpcId: messageRpcId,
               ...zone === undefined ? {} : { clientTimeZone: zone },
             })
             return ok(request, { accepted: true as const })

--- a/apps/dsh-edge/src/edge-rpc-types.ts
+++ b/apps/dsh-edge/src/edge-rpc-types.ts
@@ -89,7 +89,18 @@ export interface SessionModelsPayload { sessionId: SessionId }
 export interface SessionSelectModelPayload { sessionId: SessionId; provider: string; model: string; reasoningEffort?: string }
 export interface SessionRenamePayload { sessionId: SessionId; title: string }
 export interface SessionForkPayload { sessionId: SessionId; atSeq?: number }
-export interface SessionPromptPayload { sessionId: SessionId; mode: 'queue' | 'steer'; content: PromptContentPart[]; clientTimeZone?: string }
+export interface SessionPromptPayload {
+  sessionId: SessionId
+  mode: 'queue' | 'steer'
+  content: PromptContentPart[]
+  clientTimeZone?: string
+  /**
+   * Client-minted identity the Typert client persists on the exact accepted
+   * user message and uses to reconcile its optimistic copy; legacy envelope
+   * callers omit it and fall back to the transport rpcId.
+   */
+  requestId?: string
+}
 export interface SessionAttachmentPayload { sessionId: SessionId; attachmentId: string }
 export interface SessionUpdateQueuePayload { sessionId: SessionId; itemId: MessageId; action: QueueAction }
 export interface SessionCancelPayload { sessionId: SessionId }

--- a/apps/dsh-edge/tests/edge-api.spec.ts
+++ b/apps/dsh-edge/tests/edge-api.spec.ts
@@ -512,6 +512,21 @@ describe('Edge upstream API invariants', () => {
     expect(sessionEvent).toHaveBeenCalledWith(parentId, idleEvent)
   })
 
+  it('persists the client-minted requestId on the user message and falls back to the envelope rpcId', async () => {
+    const prompt = vi.fn(async () => {})
+    const edge = runtime({}, { prompt })
+    const content = [{ type: 'text', text: 'hello' }] satisfies PromptContentPart[]
+
+    const typert = request({ sessionId: parentId, mode: 'queue' as const, content, requestId: 'client-minted-id' })
+    const typertResponse = await createEdgeApi(edge).sessions.prompt(typert)
+    expect(typertResponse).toMatchObject({ rpcId: typert.rpcId, result: { ok: true, value: { accepted: true } } })
+    expect(prompt).toHaveBeenLastCalledWith(expect.objectContaining({ rpcId: 'client-minted-id' }))
+
+    const legacy = request({ sessionId: parentId, mode: 'queue' as const, content })
+    await createEdgeApi(edge).sessions.prompt(legacy)
+    expect(prompt).toHaveBeenLastCalledWith(expect.objectContaining({ rpcId: legacy.rpcId }))
+  })
+
   it('shares one UTF-8 text limit across prompts and queue edits', async () => {
     const updateQueue = vi.fn(() => 'accepted' as const)
     const prompt = vi.fn(async () => {})

--- a/apps/dsh-edge/tests/session.integration.mjs
+++ b/apps/dsh-edge/tests/session.integration.mjs
@@ -712,19 +712,30 @@ try {
   assert.equal(invalidRename.body.result.error.code, 'title-invalid')
   assert.equal(invalidRename.body.result.error.details.sessionId, protocolSessionId)
 
-  const protocolPrompt = await rpc('session.prompt', {
-    sessionId: protocolSessionId,
-    mode: 'queue',
-    content: [{ type: 'text', text: 'upstream protocol path' }],
-    clientTimeZone: 'UTC',
+  // The Typert client mints its own requestId and reconciles its optimistic
+  // user message against message.source.rpcId, so the persisted message must
+  // carry that id rather than the transport envelope's rpcId.
+  const protocolRequestId = `client-minted-${crypto.randomUUID()}`
+  const protocolPrompt = await typertRpc('session', 'prompt', {
+    request: {
+      requestId: protocolRequestId,
+      sessionId: protocolSessionId,
+      mode: 'queue',
+      content: [{ type: 'text', text: 'upstream protocol path' }],
+      clientTimeZone: 'UTC',
+    },
   })
-  assert.equal(protocolPrompt.body.result.ok, true)
+  assert.equal(protocolPrompt.body.result.ok, true, JSON.stringify(protocolPrompt.body))
   assert.equal(protocolPrompt.body.result.value.accepted, true)
+  assert.notEqual(protocolPrompt.rpcId, protocolRequestId)
   const admittedHistory = await rpc('session.history', { sessionId: protocolSessionId })
   const admittedPrompt = admittedHistory.body.result.value.events
     .find(entry => entry.event.type === 'agent/inbox/spliced'
-      && entry.event.data.inserted?.some(message => message.source.rpcId === protocolPrompt.rpcId))
+      && entry.event.data.inserted?.some(message => message.source.rpcId === protocolRequestId))
   assert.notEqual(admittedPrompt, undefined)
+  assert.equal(admittedHistory.body.result.value.events.some(entry =>
+    entry.event.type === 'agent/inbox/spliced'
+      && entry.event.data.inserted?.some(message => message.source.rpcId === protocolPrompt.rpcId)), false)
   await host.next(message => message.payload.type === 'host/session-status'
     && message.payload.sessionId === protocolSessionId
     && message.payload.running === true)
@@ -744,7 +755,7 @@ try {
   assert.equal(protocolHistory.body.result.ok, true)
   const protocolUser = protocolHistory.body.result.value.events
     .find(entry => entry.event.type === 'user/message')
-  assert.equal(protocolUser.event.data.source.rpcId, protocolPrompt.rpcId)
+  assert.equal(protocolUser.event.data.source.rpcId, protocolRequestId)
   const protocolPromptProjection = await mux.next(message =>
     message.payload.type === 'session/projection'
       && message.payload.sessionId === protocolSessionId


### PR DESCRIPTION
## Problem

Found in local testing of the 0.10.0-alpha.1 candidate: after sending a message, the user message appears a second time below the assistant reply; a page reload shows it once.

Upstream's `SessionPromptRequest` carries a client-minted `requestId` ("persisted on the exact accepted user message"), the upstream controller stamps `source.rpcId = request.requestId`, and the client reconciles its optimistic user message against that id. The Edge-owned prompt path (kept by #125 for the turn lifecycle) stamped the transport envelope's `rpcId` instead. With the legacy client both ids were the same value; on the Typert route they differ, so the optimistic copy never matched the persisted event. This is an Edge regression, not an upstream change.

## Fix

- `SessionPromptPayload.requestId?` is accepted; the prompt handler persists it as the user message's `source.rpcId` when present and falls back to the envelope `rpcId` for legacy envelope callers. Response correlation still uses the envelope id.

## Validation

- Unit: the handler forwards `requestId` as the message rpcId and falls back to the envelope id without it.
- Integration (both Worker modes): the protocol prompt now goes through `/api/session/prompt` with its own `requestId`; the admitted `agent/inbox/spliced` message and the `user/message` event carry that id, and no message carries the envelope id. The legacy queue prompt assertion keeps covering the fallback.
- `pnpm run check` (319), standalone verify, snapshot 4/4, gzip 879289/921600.
- Manually verified locally that the duplicate no longer appears.

🤖 Generated with [Claude Code](https://claude.com/claude-code)