### PR TITLE
release: dsh-edge 0.11.0

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.11.0.i18n.yaml
+++ b/docs/releases/0.11.0.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.11.0.md: 3b5d2de9c3413c377aebfc27ecb12ab2fee4ef1d
+0.11.0.zh.md: 77379b9efa1762887e3a560bb5ed432b20538fe0

--- a/docs/releases/0.11.0.md
+++ b/docs/releases/0.11.0.md
@@ -1,0 +1,25 @@
+## dsh-edge 0.11.0
+
+Interactive agent capabilities on the 0.1.2-rc.1 baseline: user questions, plan mode, cross-session and file references, the plugin inventory, and an in-app workspace directory browser. Every feature installs the upstream package as published; the Edge adds only the seam Cloudflare Workers cannot provide. The assembled client bundle grows from 39 to 44 plugins.
+
+### Added
+
+- **User questions** (#136): the upstream `dsh-user-questions` seam and the `ask_user_question` tool (`dsh-tool-ask-user`) let the model ask the user a structured question; the browser renders it as a question card and answers through the gateway's own `$events/result` endpoint. The upstream `dsh-api-remotes` host entry now forwards session events to the browser, replacing the Edge's hand-written `$events` source, and a small Edge `connection` seam captures the gateway's RPC interceptor so `/api/$events/result` reaches it on Workers.
+- **Plan mode** (#140): upstream `dsh-plan-mode` adds `/plan`, `/plan off`, the `plan:policy` prompt section, and the `exit_plan_mode` tool whose review arrives as a question card with Approve and Keep planning. The Edge supplies the deployment guidance text; plan mode is guidance only and every tool stays callable. `dsh-client-ui-plan` joins the Web assembly.
+- **Session and file references** (#138): upstream `dsh-session-reference` resolves `@` mentions of other sessions and appends their snapshot as untrusted context; the upstream `dsh-file-reference` seam is served by an Edge provider over the Computer VFS that lists one directory per query (a trailing slash descends) and refuses paths outside the working directory. `dsh-client-ui-reference` joins the Web assembly.
+- **Plugin inventory** (#137): the upstream `dsh-host-plugin-inventory` gateway answers Settings → Plugins from an Edge `loader` projection: host plugins from the live cordis registry with their fiber phase, browser plugins from the reviewed boot graph. `dsh-client-ui-settings-plugins` and `dsh-client-ui-settings-plugin-inventory` join the Web assembly.
+- **Workspace directory browser** (#141): the upstream `dsh-host-directory-picker` seam is served by an Edge `browse` backend over the Computer VFS rooted at `/workspace` (listing, breadcrumbs, hidden entries, a 1000-row bound, folder creation, and the upstream error vocabulary). Add workspace now opens the upstream `dsh-client-ui-directory-picker-browse` dialog with New folder, and the Edge-only name-entry popover is removed. `DirectoryPickerController` reports `active` in the plugin inventory.
+
+### Fixed
+
+- **Conversation file links** (#143): clicking a file path in a tool row downloads the file again. The 0.1.2-rc.1 chat opens links through `session/openWorkspacePath`, which bypassed the download fallback introduced in 0.7.x; the Edge client now wraps that Remote, and the host composes `SessionController` through its `internals` seam so a native open reports "not available on Cloudflare Workers" instead of a `child_process` error. `canOpenWorkspacePath` stays false.
+- **Forwarded event results**: `POST /api/$events/<method>` dispatches through the gateway interceptor instead of the Remote `invoke()` path, which returned 404 for `$events/result`.
+
+### Technical
+
+- Agent-scoped Remotes (`commands/*`, `fileReferences/list`, `sessionReferenceResolver/candidates`) resume a cold session through the upstream controller and keep it resident until Durable Object eviction; turns still open one agent per turn.
+- No new version-bound upstream patches. The direct Worker is about 877 KiB gzip against the 900 KiB budget.
+
+### Dependencies
+
+- New upstream packages pinned at 0.1.2-rc.1: `dsh-user-questions`, `dsh-tool-ask-user`, `dsh-api-remotes`, `dsh-scope`, `dsh-plan-mode`, `dsh-session-reference`, `dsh-file-reference`, `dsh-host-plugin-inventory`, `dsh-host-directory-picker`, plus the five client plugins above.

--- a/docs/releases/0.11.0.zh.md
+++ b/docs/releases/0.11.0.zh.md
@@ -1,0 +1,25 @@
+## dsh-edge 0.11.0
+
+基于 0.1.2-rc.1 基线的交互式 agent 能力：用户提问、计划模式、跨会话与文件引用、插件清单，以及应用内工作区目录浏览器。每项功能都原样安装已发布的上游包，Edge 只补 Cloudflare Workers 无法提供的接缝。装配后的客户端包从 39 个插件增至 44 个。
+
+### 新增
+
+- **用户提问**（#136）：上游 `dsh-user-questions` 接缝和 `ask_user_question` 工具（`dsh-tool-ask-user`）让模型向用户提出结构化问题；浏览器渲染为问题卡片，并通过网关自有的 `$events/result` 端点作答。上游 `dsh-api-remotes` 宿主入口现在负责把会话事件转发到浏览器，取代 Edge 手写的 `$events` 事件源；一个很小的 Edge `connection` 接缝捕获网关注册的 RPC 拦截器，使 `/api/$events/result` 在 Workers 上可达。
+- **计划模式**（#140）：上游 `dsh-plan-mode` 提供 `/plan`、`/plan off`、`plan:policy` 提示段和 `exit_plan_mode` 工具，评审以问题卡片呈现，含"批准"和"继续规划"。Edge 提供部署方的引导文本；计划模式只是引导，所有工具仍可调用。`dsh-client-ui-plan` 加入 Web 装配。
+- **会话与文件引用**（#138）：上游 `dsh-session-reference` 解析对其他会话的 `@` 提及并把其快照作为不可信上下文附加；上游 `dsh-file-reference` 接缝由 Edge 基于 Computer VFS 的提供者服务，每次查询列举一个目录（末尾斜杠下钻），拒绝工作目录之外的路径。`dsh-client-ui-reference` 加入 Web 装配。
+- **插件清单**（#137）：上游 `dsh-host-plugin-inventory` 网关基于 Edge 的 `loader` 投影回答"设置 → 插件"页：宿主插件来自实时 cordis 注册表并带 fiber 阶段，浏览器插件来自已审核的启动图。`dsh-client-ui-settings-plugins` 与 `dsh-client-ui-settings-plugin-inventory` 加入 Web 装配。
+- **工作区目录浏览器**（#141）：上游 `dsh-host-directory-picker` 接缝由 Edge 基于 Computer VFS、以 `/workspace` 为根的 `browse` 后端服务（列举、面包屑、隐藏项、1000 行上限、新建文件夹，以及上游的错误词汇）。"添加工作区"现在打开上游 `dsh-client-ui-directory-picker-browse` 对话框并支持新建文件夹，Edge 自有的输名字弹窗已移除。`DirectoryPickerController` 在插件清单中显示为 `active`。
+
+### 修复
+
+- **对话中的文件链接**（#143）：点击工具行中的文件路径重新触发下载。0.1.2-rc.1 的聊天插件改经 `session/openWorkspacePath` 打开链接，绕过了 0.7.x 引入的下载回退；Edge 客户端现在包装该 Remote，宿主通过 `SessionController` 的 `internals` 接缝组合控制器，使原生打开报告"在 Cloudflare Workers 上不可用"而不是 `child_process` 错误。`canOpenWorkspacePath` 保持为 false。
+- **转发事件的结果回传**：`POST /api/$events/<method>` 改经网关拦截器分发，而不是 Remote 的 `invoke()` 路径，后者对 `$events/result` 返回 404。
+
+### 技术
+
+- Agent 作用域的 Remote（`commands/*`、`fileReferences/list`、`sessionReferenceResolver/candidates`）通过上游控制器唤起冷会话并常驻至 Durable Object 回收；turn 仍按每轮开启一个 agent。
+- 没有新增版本绑定的上游补丁。direct Worker 约 877 KiB gzip，预算 900 KiB。
+
+### 依赖
+
+- 新增钉在 0.1.2-rc.1 的上游包：`dsh-user-questions`、`dsh-tool-ask-user`、`dsh-api-remotes`、`dsh-scope`、`dsh-plan-mode`、`dsh-session-reference`、`dsh-file-reference`、`dsh-host-plugin-inventory`、`dsh-host-directory-picker`，以及上述五个客户端插件。


### PR DESCRIPTION
## Summary

Release PR for dsh-edge 0.11.0: bumps `apps/dsh-edge/package.json` (the only release-version source) and adds the bilingual release notes with their pairing record.

Since 0.10.0 (all on the 0.1.2-rc.1 baseline, every feature installing the upstream package as-is with a Workers-side seam only):

- #136 user questions + `ask_user_question` (upstream `dsh-user-questions`, `dsh-tool-ask-user`, `dsh-api-remotes`)
- #140 plan mode (upstream `dsh-plan-mode`, Web plan control)
- #138 session and file references (upstream `dsh-session-reference`, `dsh-file-reference` seam + Computer VFS provider)
- #137 plugin inventory (upstream `dsh-host-plugin-inventory` over an Edge `loader` projection)
- #141 workspace directory browser (upstream `dsh-host-directory-picker` seam + Computer VFS `browse` backend; Edge popover removed)
- #143 conversation file links download again on Workers

Client bundle 39 → 44 plugins. No new upstream patches. Direct Worker about 877 KiB gzip (budget 900 KiB).

## Verification

- `pnpm run doc-pairs -- --write` recorded `docs/releases/0.11.0.i18n.yaml`; `pnpm run doc-sync` passes (39 pairs consistent, legal files verified)
- `pnpm --dir apps/dsh-edge pack` (prepack gate builds both runtime modes and size-checks Direct) + `pack:verify` on the tarball outside the workspace: both installed Worker artifacts start
- `git diff --check` clean

## After merge (release procedure)

1. `git pull` main and confirm `apps/dsh-edge/package.json` reads `0.11.0`
2. `git tag dsh-edge-v0.11.0 && git push origin dsh-edge-v0.11.0` — this triggers `release-edge.yml` (build, verify, npm trusted publishing, GitHub Release)
3. Verify `npm view dsh-edge@0.11.0` and `gh release view dsh-edge-v0.11.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
