### PR TITLE
fix: declare the Web shell transport as host-owning so plugin settings render on deployed origins

### DIFF
--- a/apps/dsh-edge/README.i18n.yaml
+++ b/apps/dsh-edge/README.i18n.yaml
@@ -2,5 +2,5 @@
 # last confirmed-consistent state. Both languages carry equal authority.
 # After editing either side, update both and re-record every pair with:
 #   pnpm run doc-pairs -- --write
-README.md: f553d63c2fca4efb2886acbdafb44c90a33b8abb
-README.zh.md: 626c5f941dee82c0ec0ce4fa0278d2ccfa63c72a
+README.md: b2b8697453e7e747c1934594b06466263579794b
+README.zh.md: 3572c8a13af6280c296c0e7c178a27d913d9c133

--- a/apps/dsh-edge/README.md
+++ b/apps/dsh-edge/README.md
@@ -208,6 +208,7 @@ Invalid deployment configuration fails before session lookup or SSE response cre
 - The cookie carries no user data, is never forwarded to the Durable Object, and becomes invalid when the access key rotates.
 - Unauthenticated API and WebSocket requests return 401. Only an owner-authentication 401 carrying `WWW-Authenticate: DshEdgeOwner` makes the same-origin shell navigate to `/login`; provider/configuration 401 diagnostics remain visible.
 - Authenticated browser API and WebSocket requests from another origin return 403 even with a same-site cookie.
+- The Web shell declares the browser transport as host-owning (`__DSH_TRANSPORT__.ownsHost`), so upstream's loopback-only trust tier, which gates host-persisted plugin settings and the settings document editor, applies to the authenticated owner on any origin.
 - The asset policy prevents framing through `/`, `/index.html`, or an SPA fallback. `/` redirects to `/login`; `/api/health` and immutable assets remain public.
 
 This deliberately is not an account system or multi-tenant boundary.

--- a/apps/dsh-edge/README.zh.md
+++ b/apps/dsh-edge/README.zh.md
@@ -208,6 +208,7 @@ Cloudflare static assets -> upstream Web shell + client plugin graph
 - Cookie 不包含用户数据，不会转发给 Durable Object，并在 access key 轮换后失效。
 - 未认证的 API 与 WebSocket 请求返回 401。只有携带 `WWW-Authenticate: DshEdgeOwner` 的 owner-authentication 401 才会让同 origin shell 导航到 `/login`；provider/配置的 401 诊断仍然可见。
 - 来自其他 origin 的已认证浏览器 API 与 WebSocket 请求，即使携带 same-site cookie 也会返回 403。
+- Web shell 会把浏览器传输层声明为拥有宿主（`__DSH_TRANSPORT__.ownsHost`），因此上游仅限 loopback 的信任层级（它决定宿主持久化的插件设置和设置文档编辑器是否可用）对任意 origin 上的已认证 owner 同样生效。
 - Asset policy 会阻止通过 `/`、`/index.html` 或 SPA fallback 进行 frame 嵌入。`/` 重定向到 `/login`；`/api/health` 与 immutable asset 保持公开。
 
 这里刻意不是 account system 或多租户边界。

--- a/apps/dsh-edge/standalone/scripts/assemble-standalone-web.mjs
+++ b/apps/dsh-edge/standalone/scripts/assemble-standalone-web.mjs
@@ -7,6 +7,7 @@ import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import { ClientModuleRegistry, bootInjections, orderByModuleGraph } from '@deepseek-ai/dsh-client-modules'
 import { renderIndexInjections } from '@deepseek-ai/dsh-host-webserver'
+import { injectOwnerSessionGuard } from './web-shell-head.mjs'
 
 const standaloneRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..')
 const appRoot = resolve(standaloneRoot, '..')
@@ -105,32 +106,6 @@ function resolvePublishedPackage(name) {
     }
   }
   return undefined
-}
-
-function injectOwnerSessionGuard(html) {
-  const script = `<script>(() => {
-  const originalFetch = window.fetch.bind(window)
-  let redirecting = false
-  window.fetch = async (...args) => {
-    const input = args[0]
-    const href = input instanceof Request ? input.url : String(input)
-    const target = new URL(href, window.location.href)
-    const response = await originalFetch(...args)
-    if (!redirecting
-      && response.status === 401
-      && response.headers.get('www-authenticate') === 'DshEdgeOwner'
-      && target.origin === window.location.origin
-      && target.pathname.startsWith('/api/')) {
-      redirecting = true
-      window.location.replace('/login')
-    }
-    return response
-  }
-})()</script>`
-  const head = html.indexOf('<head>')
-  return head === -1
-    ? `${script}${html}`
-    : `${html.slice(0, head + 6)}${script}${html.slice(head + 6)}`
 }
 
 async function copyBundle(record, pkg, entries) {

--- a/apps/dsh-edge/standalone/scripts/verify-standalone.mjs
+++ b/apps/dsh-edge/standalone/scripts/verify-standalone.mjs
@@ -1,6 +1,7 @@
 /** Verify the pinned standalone dependency closure and its assembled artifacts. */
 
 import { access, readFile, readdir, stat } from 'node:fs/promises'
+import { OWNER_HOST_DECLARATION } from './web-shell-head.mjs'
 import { dirname, join, relative, resolve } from 'node:path'
 import { fileURLToPath } from 'node:url'
 import edgePackage from '../../package.json' with { type: 'json' }
@@ -107,6 +108,9 @@ const webRoot = join(standaloneRoot, 'dist')
 const index = await readFile(join(webRoot, 'index.html'), 'utf8')
 if (!index.includes('window.__ModuleLoader__=')) {
   throw new Error('Standalone Web shell omitted the upstream module-loader bootstrap facade.')
+}
+if (!OWNER_HOST_DECLARATION.test(index)) {
+  throw new Error('Standalone Web shell does not declare the browser transport as host-owning (__DSH_TRANSPORT__.ownsHost).')
 }
 const bootMatch = index.match(/globalThis\["__DSH_BOOT__"\] = (\{.*?\})<\/script>/s)
 if (bootMatch === null) throw new Error('Standalone Web shell has no boot manifest.')

--- a/apps/dsh-edge/standalone/scripts/web-shell-head.d.mts
+++ b/apps/dsh-edge/standalone/scripts/web-shell-head.d.mts
@@ -1,0 +1,8 @@
+/** Inline script body injected at the top of the assembled Web shell's `<head>`. */
+export const WEB_SHELL_HEAD_SCRIPT: string
+
+/** Pattern the standalone verifier uses to prove the shell declares `__DSH_TRANSPORT__.ownsHost`. */
+export const OWNER_HOST_DECLARATION: RegExp
+
+/** Inject the head script into an assembled index document. */
+export function injectOwnerSessionGuard(html: string): string

--- a/apps/dsh-edge/standalone/scripts/web-shell-head.mjs
+++ b/apps/dsh-edge/standalone/scripts/web-shell-head.mjs
@@ -1,0 +1,59 @@
+/**
+ * Head-of-document script the Edge injects into the assembled Web shell.
+ *
+ * Two concerns share one parser-blocking script so both apply before any
+ * upstream client plugin evaluates:
+ *
+ * 1. Host ownership. Upstream `dsh-client-connection` treats the page as a
+ *    trusted local client only when its hostname is loopback or when the
+ *    embedding shell declares `globalThis.__DSH_TRANSPORT__.ownsHost`. The
+ *    loopback tier gates host-persisted settings (plugin configuration cards,
+ *    the settings document editor) and native path affordances. An Edge
+ *    deployment always runs on a remote origin, but its only browser visitor
+ *    is the cookie-authenticated single owner, so the shell declares
+ *    ownership instead of letting the hostname heuristic classify the owner
+ *    as an untrusted remote viewer. `fetch` and `openStream` stay unset so the
+ *    default web carrier is used.
+ * 2. Owner-session guard. An owner-authentication 401 on a same-origin API
+ *    call sends the shell to `/login` instead of leaving a dead session.
+ */
+
+/** The inline script body, without `<script>` tags. */
+export const WEB_SHELL_HEAD_SCRIPT = `(() => {
+  const transport = globalThis.__DSH_TRANSPORT__
+  globalThis.__DSH_TRANSPORT__ = { ...(transport ?? {}), ownsHost: true }
+  const originalFetch = window.fetch.bind(window)
+  let redirecting = false
+  window.fetch = async (...args) => {
+    const input = args[0]
+    const href = input instanceof Request ? input.url : String(input)
+    const target = new URL(href, window.location.href)
+    const response = await originalFetch(...args)
+    if (!redirecting
+      && response.status === 401
+      && response.headers.get('www-authenticate') === 'DshEdgeOwner'
+      && target.origin === window.location.origin
+      && target.pathname.startsWith('/api/')) {
+      redirecting = true
+      window.location.replace('/login')
+    }
+    return response
+  }
+})()`
+
+/** Regex the standalone verifier uses to prove the assembled shell declares host ownership. */
+export const OWNER_HOST_DECLARATION = /globalThis\.__DSH_TRANSPORT__ = \{ \.\.\.\(transport \?\? \{\}\), ownsHost: true \}/u
+
+/**
+ * Inject the head script at the top of `<head>` (or before everything when the
+ * document has no head tag).
+ * @param {string} html - the assembled index document.
+ * @returns {string} the document with the script injected.
+ */
+export function injectOwnerSessionGuard(html) {
+  const script = `<script>${WEB_SHELL_HEAD_SCRIPT}</script>`
+  const head = html.indexOf('<head>')
+  return head === -1
+    ? `${script}${html}`
+    : `${html.slice(0, head + 6)}${script}${html.slice(head + 6)}`
+}

--- a/apps/dsh-edge/tests/session.browser.snapshot.mjs
+++ b/apps/dsh-edge/tests/session.browser.snapshot.mjs
@@ -4,6 +4,7 @@ import { createHmac } from 'node:crypto'
 import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { networkInterfaces } from 'node:os'
 import { chromium } from 'playwright'
 import { describe, expect, it } from 'vitest'
 import { unstable_dev } from 'wrangler'
@@ -17,6 +18,19 @@ import { startMockDeepSeek } from './fixtures/mock-deepseek.mjs'
 const edgePackage = JSON.parse(readFileSync(new URL('../package.json', import.meta.url), 'utf8'))
 const mockChannelVersion = `${Number(edgePackage.version.split('.')[0]) + 1}.0.0`
 const ACCESS_KEY = 'browser-snapshot-owner-key-32-bytes'
+
+
+/** First routable private IPv4 address of this machine, or undefined when it only has loopback. */
+function lanIPv4Address() {
+  for (const entries of Object.values(networkInterfaces())) {
+    for (const entry of entries ?? []) {
+      if (entry.family !== 'IPv4' || entry.internal) continue
+      if (entry.address.startsWith('169.254.')) continue
+      if (/^(10\.|192\.168\.|172\.(1[6-9]|2\d|3[01])\.)/u.test(entry.address)) return entry.address
+    }
+  }
+  return undefined
+}
 
 describe('dsh-edge assembled browser snapshot', () => {
   it('pins the transcript rendered through the upstream Web client and Edge protocol', async () => {
@@ -126,6 +140,78 @@ describe('dsh-edge assembled browser snapshot', () => {
         () => settings.locator('[data-plugin-entry]').count(),
         { timeout: 15_000 },
       ).toBe(inventoryIds.length)
+
+      // Upstream classifies the page as a trusted local client only on a
+      // loopback hostname or when the shell declares host ownership. The Edge
+      // shell declares it, so the host-persisted plugin configuration cards
+      // must render from a non-loopback origin exactly as they do on 127.0.0.1.
+      // Browsers send Sec-Fetch headers only to secure contexts, and the Edge
+      // login refuses a form post without them, so the remote instance serves
+      // HTTPS on every interface and the page reaches it through a LAN address.
+      const lanAddress = lanIPv4Address()
+      if (lanAddress === undefined) {
+        console.warn('[browser snapshot] no LAN IPv4 interface; skipping the non-loopback origin check')
+      } else {
+        const remoteState = mkdtempSync(join(tmpdir(), 'dsh-edge-browser-remote-'))
+        const remoteConfig = join(remoteState, 'wrangler.json')
+        await writePrebuiltModeWranglerConfig('direct', remoteConfig)
+        let remoteWorker
+        let remoteBrowser
+        try {
+          remoteWorker = await unstable_dev(workerArtifactPath('direct'), {
+            config: remoteConfig,
+            persistTo: remoteState,
+            ip: '0.0.0.0',
+            localProtocol: 'https',
+            vars: {
+              DEEPSEEK_API_KEY: 'keyless-browser-remote-no-call',
+              DSH_EDGE_ACCESS_KEY: ACCESS_KEY,
+            },
+            logLevel: 'error',
+            experimental: {
+              disableExperimentalWarning: true,
+              showInteractiveDevSession: false,
+              watch: false,
+            },
+          })
+          remoteBrowser = await chromium.launch({
+            ...(channel ? { channel } : {}),
+            // A system proxy would otherwise carry the LAN request away from the
+            // local instance.
+            args: ['--no-proxy-server'],
+          })
+          const remoteOrigin = `https://${lanAddress}:${String(remoteWorker.port)}`
+          const remotePage = await remoteBrowser.newPage({ locale: 'en-US', ignoreHTTPSErrors: true })
+          await remotePage.goto(remoteOrigin, { waitUntil: 'load' })
+          await remotePage.getByLabel('Owner access key').fill(ACCESS_KEY)
+          await remotePage.getByRole('button', { name: 'Unlock', exact: true }).click()
+          await remotePage.waitForURL(`${remoteOrigin}/`)
+          await remotePage.waitForSelector('[class*="frame"]', { timeout: 30_000 })
+          // The app shell (not the script-free login page) carries the declaration.
+          expect(await remotePage.evaluate(() => globalThis.__DSH_TRANSPORT__?.ownsHost)).toBe(true)
+          const remoteContinue = remotePage.getByRole('button', { name: 'Continue', exact: true })
+          if (await remoteContinue.count() > 0
+            || await remoteContinue.waitFor({ timeout: 5_000 }).then(() => true, () => false)) {
+            await remoteContinue.click()
+          }
+          await remotePage.locator('button[aria-haspopup="dialog"]').last().click()
+          const remoteSettings = remotePage.getByRole('dialog', { name: 'Settings', exact: true })
+          await remoteSettings.getByRole('navigation')
+            .getByRole('button', { name: 'Plugins', exact: true })
+            .click()
+          await remoteSettings.getByRole('tab', { name: 'Plugin configuration', exact: true }).waitFor()
+          for (const card of ['Agent loop', 'Web search']) {
+            await expect.poll(
+              () => remoteSettings.getByRole('button', { name: `Show settings: ${card}`, exact: true }).count(),
+              { timeout: 15_000 },
+            ).toBe(1)
+          }
+        } finally {
+          await remoteBrowser?.close()
+          await remoteWorker?.stop()
+          rmSync(remoteState, { recursive: true, force: true })
+        }
+      }
       await settings.getByRole('button', { name: 'Agent presets', exact: true }).click()
       const presetReadResponse = page.waitForResponse(response =>
         rpcResponseIs(response, 'agentPreset.read'))
@@ -427,7 +513,7 @@ describe('dsh-edge assembled browser snapshot', () => {
       await mock.close()
       rmSync(persistedState, { recursive: true, force: true })
     }
-  }, 60_000)
+  }, 120_000)
 
   it('enables upstream image intake through the temporary DO attachment backend', async () => {
     const persistedState = mkdtempSync(join(tmpdir(), 'dsh-edge-browser-temporary-'))

--- a/apps/dsh-edge/tests/web-shell-head.spec.ts
+++ b/apps/dsh-edge/tests/web-shell-head.spec.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { runInNewContext } from 'node:vm'
+import {
+  OWNER_HOST_DECLARATION,
+  WEB_SHELL_HEAD_SCRIPT,
+  injectOwnerSessionGuard,
+} from '../standalone/scripts/web-shell-head.mjs'
+
+interface ShellSandbox {
+  window: ShellSandbox
+  location: { hostname: string; href: string; origin: string; replace: (url: string) => void }
+  fetch: (...args: unknown[]) => Promise<unknown>
+  __DSH_TRANSPORT__?: Record<string, unknown>
+  URL: typeof URL
+  Request: typeof Request
+  replaced: string[]
+  Response: typeof Response
+  Headers: typeof Headers
+}
+
+/** Run the head script the way a browser would, on a non-loopback page. */
+function runShell(options: { transport?: Record<string, unknown>; status?: number; authenticate?: string } = {}): ShellSandbox {
+  const replaced: string[] = []
+  const sandbox = {
+    location: {
+      hostname: 'example.workers.dev',
+      href: 'https://example.workers.dev/',
+      origin: 'https://example.workers.dev',
+      replace: (url: string) => { replaced.push(url) },
+    },
+    fetch: async () => new Response(null, {
+      status: options.status ?? 200,
+      headers: options.authenticate === undefined ? {} : { 'www-authenticate': options.authenticate },
+    }),
+    URL,
+    Request,
+    Response,
+    Headers,
+    replaced,
+    ...(options.transport === undefined ? {} : { __DSH_TRANSPORT__: options.transport }),
+  } as unknown as ShellSandbox
+  sandbox.window = sandbox
+  runInNewContext(WEB_SHELL_HEAD_SCRIPT, sandbox)
+  return sandbox
+}
+
+describe('web shell head script', () => {
+  it('declares the browser transport as host-owning on a non-loopback origin', () => {
+    const shell = runShell()
+    expect(shell.__DSH_TRANSPORT__).toEqual({ ownsHost: true })
+  })
+
+  it('keeps a transport the embedding shell already declared', () => {
+    const fetch = async () => new Response('ok')
+    const shell = runShell({ transport: { fetch } })
+    expect(shell.__DSH_TRANSPORT__).toEqual({ fetch, ownsHost: true })
+  })
+
+  it('still redirects owner-authentication 401 responses to /login', async () => {
+    const shell = runShell({ status: 401, authenticate: 'DshEdgeOwner' })
+    await shell.window.fetch('/api/session/list')
+    expect(shell.replaced).toEqual(['/login'])
+    await shell.window.fetch('/api/session/list')
+    expect(shell.replaced).toEqual(['/login'])
+  })
+
+  it('injects the script at the top of <head> and the verifier pattern matches it', () => {
+    const html = injectOwnerSessionGuard('<html><head><title>x</title></head><body></body></html>')
+    expect(html.indexOf('<script>')).toBe('<html><head>'.length)
+    expect(OWNER_HOST_DECLARATION.test(html)).toBe(true)
+    const headless: string = injectOwnerSessionGuard('<p>no head</p>')
+    expect(headless.startsWith('<script>')).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary

Closes #145.

On a deployed origin, Settings → Plugins → **Plugin configuration** rendered blank (not even the empty-state text), while the same build on `localhost` showed the Agent loop and Web search cards.

**Root cause** (upstream client, verified in the 0.1.2-rc.1 bundles): `dsh-client-connection` computes `isLoopback = transport?.ownsHost === true || isLoopbackHostname(location.hostname)`; `dsh-client-ui-settings` uses `isLoopback ? "host" : "memory"` for its settings mirror, and in memory mode every host-persisted namespace is *unavailable*, so the plugin cards (which render nothing for an unavailable namespace) disappear. The same flag also gates the settings document editor in `dsh-client-ui-settings-general` and native open in `dsh-client-ui-deliverables`. The heuristic is written for upstream's loopback-only `dsh web`; an Edge deployment is always a remote origin, but its only browser visitor is the cookie-authenticated single owner.

**Fix**: the Edge Web shell declares the browser transport as host-owning through the upstream seam `globalThis.__DSH_TRANSPORT__ = { ...existing, ownsHost: true }`, injected at the top of `<head>` before any plugin evaluates (same script as the owner-session 401 guard, now in `standalone/scripts/web-shell-head.mjs`). `fetch` / `openStream` stay unset, so the default web carrier is unchanged. No upstream patch.

## Verification

- New `tests/web-shell-head.spec.ts` runs the injected script in `node:vm` on a `example.workers.dev` page: declares `ownsHost`, merges an existing transport, keeps the 401 → `/login` redirect, and the verifier regex matches the injected document.
- `verify-standalone.mjs` now fails the assembly if `dist/index.html` lacks the declaration.
- Browser regression (`session.browser.snapshot.mjs`): a second `unstable_dev` instance is bound to `0.0.0.0` with `localProtocol: 'https'` and opened through the machine's LAN IPv4 address (HTTPS is required because Chromium only sends `Sec-Fetch-*` to secure contexts and the Edge login refuses a form post without them; the step is skipped with a warning when no private IPv4 interface exists). It logs in, asserts `__DSH_TRANSPORT__.ownsHost === true` on the app shell, and asserts the **Agent loop** and **Web search** cards render on that non-loopback origin. Flipping the declaration to `false` in the served shell makes the step fail (checked locally). The first browser test's timeout is raised to 120 s for the extra instance.
- Options rejected: `--host-resolver-rules` mapping a fake hostname to 127.0.0.1 is hijacked by local proxy/TUN software on the dev machine; plain HTTP on a LAN IP cannot log in (no `Sec-Fetch-Site`, `Origin: null` → 403).
- Local: lint, typecheck, `web-shell-head.spec.ts` (4), standalone build + verify (44 plugins, deterministic), promote + dual-mode integration (direct and isolated pass), `test:snapshot` (3 files / 4 tests), `doc-sync` (39 pairs), `git diff --check`.

## What the flag now enables on deployed instances

- Plugins → Plugin configuration cards (Agent loop, Web search) with host persistence.
- The settings document editor in General settings.
- `dsh-client-ui-deliverables` native open stays hidden because `canOpenWorkspacePath` is false on Workers (#143).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
