### PR TITLE
release: dsh-edge 0.11.1

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.11.0",
+  "version": "0.11.1",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.11.1.i18n.yaml
+++ b/docs/releases/0.11.1.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.11.1.md: 4d362efc9b427bb950d8e71354461be2e5ba8621
+0.11.1.zh.md: 434dab9649c164e216e97ac5b53afbfabadade5e

--- a/docs/releases/0.11.1.md
+++ b/docs/releases/0.11.1.md
@@ -1,0 +1,11 @@
+## dsh-edge 0.11.1
+
+Patch release: host-persisted settings and the plugin configuration cards now render on deployed origins, not only on localhost.
+
+### Fixed
+
+- **Plugin configuration on deployed origins** (#146, closes #145): Settings → Plugins → Plugin configuration was blank on a `*.workers.dev` or custom domain while it showed the Agent loop and Web search cards on `localhost`. Upstream `dsh-client-connection` treats the page as a trusted local client only on a loopback hostname or when the embedding shell declares `globalThis.__DSH_TRANSPORT__.ownsHost`, and `dsh-client-ui-settings` keeps host-persisted namespaces unavailable otherwise. The Edge's only browser visitor is the cookie-authenticated owner, so the assembled Web shell now declares host ownership in its head script; `fetch` and `openStream` stay unset so the default web carrier is used. The same flag enables the settings document editor in General and the native-open gating in the produced-files row, which continues to hide native open because `canOpenWorkspacePath` stays false.
+
+### Technical
+
+- The injected head script moved to `standalone/scripts/web-shell-head.mjs` (owner-session guard plus the transport declaration); `verify-standalone.mjs` asserts the declaration in the assembled `index.html`, and the browser snapshot suite now also boots a second HTTPS instance reached through a LAN address to prove the cards render from a non-loopback origin.

--- a/docs/releases/0.11.1.zh.md
+++ b/docs/releases/0.11.1.zh.md
@@ -1,0 +1,11 @@
+## dsh-edge 0.11.1
+
+补丁版本：宿主持久化的设置和插件配置卡片现在在已部署的域名上也能渲染，而不只是在 localhost 上。
+
+### 修复
+
+- **已部署域名上的插件配置**（#146，关闭 #145）：在 `*.workers.dev` 或自定义域名上，"设置 → 插件 → 插件配置"是空白的，而在 `localhost` 上能看到 Agent loop 和 Web search 两张卡片。上游 `dsh-client-connection` 只在页面主机名是 loopback、或嵌入外壳声明了 `globalThis.__DSH_TRANSPORT__.ownsHost` 时才把页面视为可信的本地客户端，否则 `dsh-client-ui-settings` 会把宿主持久化的命名空间保持为不可用。Edge 的唯一浏览器访问者是经 cookie 认证的所有者，因此装配后的 Web 外壳现在在头部脚本中声明宿主所有权；`fetch` 和 `openStream` 保持未设置，继续使用默认的 Web 通道。同一标志也启用了"通用"页的设置文档编辑器，以及产出文件行的原生打开门控，后者因 `canOpenWorkspacePath` 仍为 false 而继续隐藏原生打开。
+
+### 技术
+
+- 注入的头部脚本移到 `standalone/scripts/web-shell-head.mjs`（所有者会话守卫加传输声明）；`verify-standalone.mjs` 断言装配后的 `index.html` 含该声明，浏览器快照套件现在还会额外启动一个经局域网地址访问的 HTTPS 实例，证明卡片在非 loopback 来源下也能渲染。


### PR DESCRIPTION
## Summary

Patch release PR for dsh-edge 0.11.1: bumps `apps/dsh-edge/package.json` and adds the bilingual release notes with their pairing record.

Since 0.11.0:

- #146 (closes #145): the assembled Web shell declares `globalThis.__DSH_TRANSPORT__.ownsHost`, so upstream's loopback-only trust tier applies to the cookie-authenticated owner on any origin. Settings → Plugins → Plugin configuration and the other host-persisted settings render on deployed domains again.

## Verification

- `pnpm run doc-pairs -- --write` recorded `docs/releases/0.11.1.i18n.yaml`; `pnpm run doc-sync` passes (40 pairs consistent, legal files verified)
- `pnpm --dir apps/dsh-edge pack` + `pack:verify` outside the workspace: both installed Worker artifacts start; the packed `dist/index.html` carries the `ownsHost: true` declaration
- `git diff --check` clean

## After merge

1. `git pull`, confirm `apps/dsh-edge/package.json` reads `0.11.1`
2. `git tag dsh-edge-v0.11.1 && git push origin dsh-edge-v0.11.1` triggers `release-edge.yml`
3. Verify `npm view dsh-edge@0.11.1` and `gh release view dsh-edge-v0.11.1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
