### PR TITLE
fix(edge): restore browser streams after DO hibernation

### DIFF
--- a/apps/dsh-edge/src/instance.ts
+++ b/apps/dsh-edge/src/instance.ts
@@ -336,6 +336,13 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
   })
   private readonly apiFetch = (request: Request) => dispatchEdgeApi(this.api, request)
 
+  constructor(ctx: DurableObjectState, env: EdgeEnv) {
+    super(ctx, env)
+    // HTTP/alarm wakes must also reconnect hibernation-restored Remote carriers.
+    // Otherwise an open socket can outlive all its process-local stream pumps.
+    this.closeExpiredDownlinks()
+  }
+
   /** Serve session routes forwarded by the entry Worker. */
   override async fetch(request: Request): Promise<Response> {
     try {
@@ -1017,6 +1024,10 @@ export class DshEdgeInstance extends DshEdgeWorkspace {
       const attachment = readDownlinkAttachment(socket)
       if (attachment === undefined || attachment.expiresAt * 1_000 <= now) {
         socket.close(OWNER_SESSION_EXPIRED_CLOSE_CODE, OWNER_SESSION_EXPIRED_CLOSE_REASON)
+        continue
+      }
+      if (attachment.channel === 'remote.mux' && !remoteStreams.has(socket)) {
+        socket.close(1011, 'Remote stream state was lost; reconnect')
         continue
       }
       const expiresAt = attachment.expiresAt * 1_000

--- a/apps/dsh-edge/tests/remote-idle.browser.snapshot.mjs
+++ b/apps/dsh-edge/tests/remote-idle.browser.snapshot.mjs
@@ -1,0 +1,56 @@
+/** Regression: a parked browser must reconnect when HTTP wakes its hibernated DO. */
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { chromium } from 'playwright'
+import { expect, it } from 'vitest'
+import { unstable_dev } from 'wrangler'
+import { workerArtifactPath, writePrebuiltModeWranglerConfig } from '../scripts/wrangler-config.mjs'
+import { startMockDeepSeek } from './fixtures/mock-deepseek.mjs'
+
+it('restores live browser subscriptions after an idle DO wakes for a prompt', async () => {
+  const state = mkdtempSync(join(tmpdir(), 'dsh-remote-idle-'))
+  const config = join(state, 'wrangler.json')
+  const mode = process.env.DSH_EDGE_TEST_RUNTIME_MODE ?? 'direct'
+  const ownerKey = 'idle-browser-fixture-owner-key-32-bytes'
+  const mock = await startMockDeepSeek()
+  let worker, browser
+  try {
+    await writePrebuiltModeWranglerConfig(mode, config)
+    worker = await unstable_dev(workerArtifactPath(mode), {
+      config, env: mode === 'direct' ? '' : 'isolated', persistTo: state,
+      vars: { DSH_EDGE_ACCESS_KEY: ownerKey, DEEPSEEK_API_KEY: 'local-fixture-only', DEEPSEEK_BASE_URL: mock.url },
+      logLevel: 'error',
+      experimental: { disableExperimentalWarning: true, showInteractiveDevSession: false, watch: false },
+    })
+    browser = await chromium.launch(process.env.DSH_EDGE_PLAYWRIGHT_CHANNEL ? { channel: process.env.DSH_EDGE_PLAYWRIGHT_CHANNEL } : {})
+    const context = await browser.newContext()
+    const origin = `http://${worker.address}:${worker.port}`
+    expect((await context.request.post(`${origin}/api/auth/login`, { form: { accessKey: ownerKey } })).ok()).toBe(true)
+    const page = await context.newPage()
+    let carrierCloses = 0
+    page.on('websocket', socket => {
+      if (socket.url().endsWith('/api/remote.mux')) socket.on('close', () => { carrierCloses++ })
+    })
+    await page.goto(origin)
+    const onboarding = page.getByRole('button', { name: 'Continue', exact: true })
+    if (await onboarding.waitFor({ timeout: 5000 }).then(() => true, () => false)) await onboarding.click()
+    const input = page.getByRole('textbox').last()
+    await input.waitFor()
+    // Local workerd needs a genuinely idle period to evict the JS owner while
+    // preserving its accepted WebSockets. Do not poll the DO during this wait.
+    const beforeIdle = carrierCloses
+    await page.waitForTimeout(150_000)
+    await input.fill('hello after idle')
+    await page.getByRole('button', { name: 'Send message', exact: true }).click()
+    await page.getByText('remembered-alpha', { exact: true }).waitFor({ timeout: 30_000 })
+    expect(carrierCloses).toBeGreaterThan(beforeIdle)
+    expect(mock.requests.some(request => request.messages.some(message => message.content === 'hello after idle'))).toBe(true)
+  } finally {
+    mock.releaseSlowResponses()
+    await browser?.close()
+    await worker?.stop()
+    await mock.close()
+    rmSync(state, { recursive: true, force: true })
+  }
+}, 240_000)


### PR DESCRIPTION
After a browser sits idle long enough for the Durable Object to hibernate, sending a prompt over HTTP can complete the model/tool work while the page displays only its optimistic user message. The WebSocket survives hibernation, but its process-local Remote stream pumps do not; previously the server only requested reconnection when another WebSocket message arrived.

Reconcile restored downlinks in the DO constructor, covering HTTP and alarm wakes as well as WebSocket wakes. Expired owner sessions retain the existing expiry close behavior; otherwise a Remote carrier without stream state closes with the existing reconnect code so the browser reopens its logical streams and receives the persisted snapshot.

Validation:
- Reproduced on merged main with a real local Worker and browser after 150 seconds idle: model request ran, browser reply timed out.
- Added a browser regression that waits 150 seconds without polling the DO, sends through the native composer, and asserts both carrier reconnection and the rendered reply. Passed against exact promoted Direct and Dynamic artifacts.
- `pnpm run check`: 372 tests, lint and both typechecks passed.
- Both standalone builds/verifier and full dual-mode session integration passed; existing browser/runtime snapshots passed.

The regression adds about 2.5 minutes to the browser snapshot suite. No upstream patch, schema, binding, or credential-storage changes.
