### PR TITLE
chore(release): prepare 0.13.0-alpha.1

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.12.0",
+  "version": "0.13.0-alpha.1",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.13.0-alpha.1.i18n.yaml
+++ b/docs/releases/0.13.0-alpha.1.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.13.0-alpha.1.md: cab30056edd76b6bab337a65cb57f56e9acd79ed
+0.13.0-alpha.1.zh.md: fa73c3a7e6fe63980ebf541c92d7cd341e8b7bc3

--- a/docs/releases/0.13.0-alpha.1.md
+++ b/docs/releases/0.13.0-alpha.1.md
@@ -1,0 +1,19 @@
+## dsh-edge 0.13.0-alpha.1
+
+Alpha preview of subagent delegation. Published to npm's `next` channel for testing; the stable `latest` channel is unchanged. The upstream baseline remains 0.1.2-rc.1.
+
+### Added
+
+- **One-shot subagent delegation** (#156): the LLM can now delegate focused subtasks to a child agent running inside the same Durable Object. The upstream `dsh-subagent` runtime, `spawn-in-process` provider, and `dsh-tool-subagent` are mounted as-is. The child agent shares the parent's workspace VFS, shell backend, and LLM adapter. Delegation depth is capped at one level (`maxDepth: 1`); background and continuable modes are not enabled.
+- **Automatic child shell binding**: child agents inherit the parent's Computer shell binding through an `agent/created` listener. The `EdgeShellBindings.get()` method exposes parent bindings for lookup. Disposal releases the child binding automatically.
+- **Subagent session events**: child session events are broadcast through the existing mux WebSocket downlink. The upstream `dsh-client-ui-subagent` plugin renders a lineage switcher in the browser banner.
+
+### Changed
+
+- **Standalone gzip budget raised to 3 MiB**: Cloudflare removed the compressed Worker size limit on 2026-09-04 (new limit: 64 MiB uncompressed, free and paid plans unified). The repository budget remains as a code-size guardrail but no longer corresponds to a platform constraint. The subagent packages add approximately 22 KiB gzip to the direct Worker bundle.
+
+### Try the alpha
+
+Upgrade an existing installation with `npx dsh-edge@0.13.0-alpha.1 upgrade`, or create a new installation with `npx dsh-edge@0.13.0-alpha.1 install`. Keep the same named Worker and runtime mode when upgrading to retain its Durable Object data. The upgrade asks for the owner access key again because Cloudflare secrets are write-only.
+
+Suggested checks: ask the agent to delegate a file-creation task to a subagent; verify the child's output appears in the parent's conversation; check the lineage switcher in the browser banner shows the child session; try asking for nested delegation (should be refused with a depth error). The subagent tool is foreground-only: the model waits for the child to finish before continuing.

--- a/docs/releases/0.13.0-alpha.1.zh.md
+++ b/docs/releases/0.13.0-alpha.1.zh.md
@@ -1,0 +1,19 @@
+## dsh-edge 0.13.0-alpha.1
+
+子代理委派功能的 Alpha 预览版。发布至 npm 的 `next` 频道供测试；稳定的 `latest` 频道保持不变。上游基线仍为 0.1.2-rc.1。
+
+### 新增
+
+- **一次性子代理委派** (#156)：LLM 现在可以将聚焦的子任务委派给在同一 Durable Object 内运行的子代理。上游 `dsh-subagent` 运行时、`spawn-in-process` 提供者和 `dsh-tool-subagent` 均已原样挂载。子代理与父代理共享工作区 VFS、Shell 后端和 LLM 适配器。委派深度上限为一级（`maxDepth: 1`）；后台模式和可续模式均未启用。
+- **自动子代理 Shell 绑定**：子代理通过 `agent/created` 监听器自动继承父代理的 Computer Shell 绑定。`EdgeShellBindings.get()` 方法暴露父代理绑定以供查询。销毁时自动释放子代理绑定。
+- **子代理会话事件**：子会话事件通过现有的 mux WebSocket 下行链路广播。上游 `dsh-client-ui-subagent` 插件在浏览器横幅中渲染血缘关系切换器。
+
+### 变更
+
+- **Standalone gzip 预算提高至 3 MiB**：Cloudflare 于 2026-09-04 取消了 Worker 压缩大小限制（新限制：64 MiB 未压缩，免费和付费计划统一）。仓库预算仍作为代码体积护栏保留，但不再对应平台约束。子代理包为 Direct Worker 构建增加约 22 KiB gzip。
+
+### 试用 Alpha 版
+
+使用 `npx dsh-edge@0.13.0-alpha.1 upgrade` 升级现有安装，或使用 `npx dsh-edge@0.13.0-alpha.1 install` 创建新安装。升级时保持相同的 Worker 名称和运行时模式以保留 Durable Object 数据。升级时会重新要求输入所有者访问密钥，因为 Cloudflare secrets 是只写的。
+
+建议检查：要求代理将文件创建任务委派给子代理；验证子代理的输出出现在父对话中；检查浏览器横幅中的血缘关系切换器是否显示子会话；尝试请求嵌套委派（应该收到深度错误拒绝）。子代理工具仅支持前台模式：模型会等待子代理完成后再继续。


### PR DESCRIPTION
## Summary

- Bump version to `0.13.0-alpha.1`
- Add bilingual release notes for subagent delegation alpha

### What's new in 0.13.0-alpha.1

- **One-shot subagent delegation** (#156): LLM can delegate focused subtasks to a child agent inside the same DO
- **Standalone gzip budget raised to 3 MiB**: Cloudflare removed compressed limit 2026-09-04

## Test plan

- [x] `pnpm run check` passes (lint, 384 tests, typecheck)
- [x] `pnpm run doc-pairs -- --write` — 44 bilingual pairs consistent
- [x] Pre-commit hooks pass (bilingual docs, legal files, whitespace)

🤖 Generated with [Claude Code](https://claude.com/claude-code)