### PR TITLE
fix(edge): implement composedPreset/composeFrom for subagent creation

### DIFF
--- a/apps/dsh-edge/src/session-store.ts
+++ b/apps/dsh-edge/src/session-store.ts
@@ -216,6 +216,40 @@ export class EdgeSessionCwdConflictError extends Error {
 }
 
 /**
+ * The Edge ships exactly one system preset; the controller stamps its id
+ * into every created session's metadata so the banner chip and preset
+ * roster stay consistent with the Edge API's agentPresets namespace.
+ *
+ * The subagent runtime calls `composedPreset` to stamp a child session's
+ * durable header and `composeFrom` to join a child's scope to the parent's
+ * composition. Because the Edge mounts tools and prompt sections on the
+ * root context, `composeFrom` is a no-op — the child's scope chain
+ * already inherits everything.
+ */
+export class EdgeAgentPresets extends CordisService {
+  constructor(ctx: Context) { super(ctx, 'agentPresets') }
+  async resolve(presetId?: string): Promise<{ id: string; trust: 'system'; isDefault: true }> {
+    if (presetId !== undefined && presetId !== 'dsh-edge') {
+      throw new Error(`Agent preset "${presetId}" is not available.`)
+    }
+    return { id: 'dsh-edge', trust: 'system', isDefault: true }
+  }
+  async mount(): Promise<void> {
+    // The Edge system prompt and tool composition are mounted globally.
+  }
+  async compositionInventory(): Promise<readonly never[]> {
+    // No per-preset composition rows: the plugin inventory lists the
+    // global composition and the browser boot graph instead.
+    return []
+  }
+  composedPreset(_ctx: Context): string { return 'dsh-edge' }
+  composeFrom(_childCtx: Context, _parentCtx: Context): void {
+    // Edge composition is mounted on the root context, so the child's
+    // scope chain already inherits every tool and prompt section.
+  }
+}
+
+/**
  * Edge-facing facade over the same SessionStore + SessionPersistence services
  * used by upstream. Durable Object SQL is visible only to the backend plugin.
  */
@@ -386,26 +420,6 @@ export class EdgeSessionStore {
     await this.context.plugin(EdgeFileReferenceService, {
       withFiles: read => config.withWorkspaceFiles(read),
     })
-    // The Edge ships exactly one system preset; the controller stamps its id
-    // into every created session's metadata so the banner chip and preset
-    // roster stay consistent with the Edge API's agentPresets namespace.
-    const EdgeAgentPresets = class extends CordisService {
-      constructor(ctx: Context) { super(ctx, 'agentPresets') }
-      async resolve(presetId?: string): Promise<{ id: string; trust: 'system'; isDefault: true }> {
-        if (presetId !== undefined && presetId !== 'dsh-edge') {
-          throw new Error(`Agent preset "${presetId}" is not available.`)
-        }
-        return { id: 'dsh-edge', trust: 'system', isDefault: true }
-      }
-      async mount(): Promise<void> {
-        // The Edge system prompt and tool composition are mounted globally.
-      }
-      async compositionInventory(): Promise<readonly never[]> {
-        // No per-preset composition rows: the plugin inventory lists the
-        // global composition and the browser boot graph instead.
-        return []
-      }
-    }
     await this.context.plugin(EdgeAgentPresets)
     // Upstream plugin inventory injects the cordis Loader. The Edge composes
     // programmatically, so EdgeLoader answers its read-only entries() from the

--- a/apps/dsh-edge/tests/agent.spec.ts
+++ b/apps/dsh-edge/tests/agent.spec.ts
@@ -33,7 +33,7 @@ import {
   resolveEdgeStreamIdleTimeoutMs,
 } from '../src/deepseek.ts'
 import { EdgeExecutionId } from '../src/protocol.ts'
-import { createDurablePromptAdmitter, disposeAgentHandle } from '../src/session-store.ts'
+import { createDurablePromptAdmitter, disposeAgentHandle, EdgeAgentPresets } from '../src/session-store.ts'
 
 class ScriptedAdapter extends LlmAdapter {
   readonly requests: GenerateOptions[] = []
@@ -308,6 +308,7 @@ describe('dsh-edge subagent delegation', () => {
     await ctx.plugin(SessionProjectionRegistry)
     await ctx.plugin(AgentRegistry)
     await ctx.plugin(AgentLoop, { agents: [] })
+    await ctx.plugin(EdgeAgentPresets)
 
     const { default: SubagentRuntime } = await import('@deepseek-ai/dsh-subagent')
     await ctx.plugin(SubagentRuntime)
@@ -325,9 +326,15 @@ describe('dsh-edge subagent delegation', () => {
     ctx.llm.registerAdapter(['deepseek-official'], adapter)
     ctx.tools.register(createEdgeBashTool(shells))
 
+    const childHeaders: { id: string; parentSession: string; agentPreset: string | undefined }[] = []
     ctx.on('agent/created', ({ agent }) => {
       const parentId = agent.session.header.parentSession
       if (parentId === undefined) return
+      childHeaders.push({
+        id: agent.session.header.id as string,
+        parentSession: parentId as string,
+        agentPreset: agent.session.header.agentPreset,
+      })
       const parentShell = shells.get(parentId)
       if (parentShell === undefined) return
       const cwd = agent.session.header.cwd ?? parentShell.cwd
@@ -345,7 +352,7 @@ describe('dsh-edge subagent delegation', () => {
     const events: SessionEvent[] = []
     ctx.on('session/event', (_subject, event) => { events.push(event) })
     const releaseShell = shells.bind(sessionId, shell, '/workspace')
-    return { ctx, agent, handle, adapter, shells, events, releaseShell }
+    return { ctx, agent, handle, adapter, shells, events, childHeaders, releaseShell }
   }
 
   it('registers the subagent tool alongside bash', async () => {
@@ -376,7 +383,30 @@ describe('dsh-edge subagent delegation', () => {
     try {
       await followup(runtime.agent, 'Create a test file using a subagent')
       expect(runtime.adapter.requests.length).toBeGreaterThanOrEqual(2)
-      expect(runtime.events.some(e => e.type === 'turn/end')).toBe(true)
+      const toolCall = runtime.events.find(
+        e => e.type === 'tool/call' && (e.data as { name?: string }).name === 'subagent',
+      )
+      expect(toolCall).toBeDefined()
+      const callId = (toolCall!.data as { callId: string }).callId
+      const toolResult = runtime.events.find(
+        e => e.type === 'tool/result'
+          && ((e.data as { message?: { source?: { callId?: string } } }).message?.source?.callId === callId),
+      )
+      expect(toolResult).toBeDefined()
+      const resultContent = (toolResult!.data as {
+        message: { content: { isError: boolean }[] }
+      }).message.content[0]!
+      expect(resultContent.isError).toBe(false)
+      expect(runtime.childHeaders.length).toBeGreaterThanOrEqual(1)
+      expect(runtime.childHeaders[0]).toMatchObject({
+        parentSession: runtime.agent.session.header.id,
+        agentPreset: 'dsh-edge',
+      })
+      const childRequest = runtime.adapter.requests[1]!
+      expect(childRequest.sessionId).not.toBe(runtime.agent.id)
+      expect(childRequest.tools).toEqual(
+        expect.arrayContaining([expect.objectContaining({ name: 'bash' })]),
+      )
     } finally {
       runtime.releaseShell()
       await runtime.ctx.fiber.dispose()


### PR DESCRIPTION
## Summary

- The upstream `dsh-subagent` runtime calls `composedPreset()` and `composeFrom()` on the `agentPresets` service when creating child agents. `EdgeAgentPresets` only had `resolve`/`mount`/`compositionInventory`, so subagent creation threw `composedPreset is not a function` at runtime.
- Added both methods: `composedPreset` returns `'dsh-edge'` (the single Edge preset), `composeFrom` is a no-op since Edge mounts composition globally.
- Hoisted `EdgeAgentPresets` to a named export so the test harness registers it, closing the gap where the subagent test suite passed vacuously without the real service.
- Strengthened the delegation test to verify `isError: false`, child session header (`parentSession`, `agentPreset`), and that the child's LLM request includes `bash` in its tools.

## Test plan

- [x] `pnpm run check` passes (lint, typecheck, 384 unit tests)
- [x] `pnpm --filter dsh-edge run test:integration` passes (direct + isolated)
- [x] Negative test: removing the new methods causes `isError: true` on the subagent tool result
- [ ] Manual verification of scenarios A–C from the subagent test report on the dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)