### PR TITLE
chore(release): prepare 0.13.0-alpha.2

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.13.0-alpha.1",
+  "version": "0.13.0-alpha.2",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.13.0-alpha.2.i18n.yaml
+++ b/docs/releases/0.13.0-alpha.2.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.13.0-alpha.2.md: 7a2634474d4530bb5471eced05128309e1158431
+0.13.0-alpha.2.zh.md: deae4a4566cceb71f066901305029b1288214f35

--- a/docs/releases/0.13.0-alpha.2.md
+++ b/docs/releases/0.13.0-alpha.2.md
@@ -1,0 +1,13 @@
+## dsh-edge 0.13.0-alpha.2
+
+Bugfix for subagent delegation introduced in alpha.1. Published to npm's `next` channel; the stable `latest` channel is unchanged. The upstream baseline remains 0.1.2-rc.1.
+
+### Fixed
+
+- **Subagent creation crash** (#158): the upstream `dsh-subagent` runtime calls `composedPreset()` and `composeFrom()` on the `agentPresets` service when creating a child agent. The Edge's implementation only had `resolve`, `mount`, and `compositionInventory`, so every subagent delegation threw `composedPreset is not a function`. Added both methods: `composedPreset` returns the Edge preset id; `composeFrom` is a no-op because Edge composition is mounted globally. Extracted `EdgeAgentPresets` as a named export so unit tests exercise the real service.
+
+### Try the alpha
+
+Upgrade with `npx dsh-edge@0.13.0-alpha.2 upgrade`, or install fresh with `npx dsh-edge@0.13.0-alpha.2 install`. Keep the same named Worker and runtime mode when upgrading to retain Durable Object data.
+
+After upgrading, retry the subagent delegation that failed in alpha.1: ask the agent to delegate a task to a subagent, and verify the child session appears in the lineage switcher.

--- a/docs/releases/0.13.0-alpha.2.zh.md
+++ b/docs/releases/0.13.0-alpha.2.zh.md
@@ -1,0 +1,13 @@
+## dsh-edge 0.13.0-alpha.2
+
+修复 alpha.1 中引入的子代理委派问题。发布至 npm 的 `next` 频道；稳定的 `latest` 频道保持不变。上游基线仍为 0.1.2-rc.1。
+
+### 修复
+
+- **子代理创建崩溃** (#158)：上游 `dsh-subagent` 运行时在创建子代理时会调用 `agentPresets` 服务的 `composedPreset()` 和 `composeFrom()` 方法。Edge 的实现仅有 `resolve`、`mount` 和 `compositionInventory`，因此每次子代理委派都会抛出 `composedPreset is not a function`。添加了两个方法：`composedPreset` 返回 Edge 预设 ID；`composeFrom` 为空操作，因为 Edge 的组合挂载在全局上下文。将 `EdgeAgentPresets` 提取为命名导出，以便单元测试能验证真实的服务类。
+
+### 试用 Alpha 版
+
+使用 `npx dsh-edge@0.13.0-alpha.2 upgrade` 升级现有安装，或使用 `npx dsh-edge@0.13.0-alpha.2 install` 创建新安装。升级时保持相同的 Worker 名称和运行时模式以保留 Durable Object 数据。
+
+升级后，请重试在 alpha.1 中失败的子代理委派：要求代理将任务委派给子代理，并验证子会话出现在血缘关系切换器中。


### PR DESCRIPTION
## Summary

- Bump version to `0.13.0-alpha.2`
- Add bilingual release notes documenting the subagent `composedPreset` fix (#158)

## Test plan

- [x] `pnpm run check` passes (45 doc pairs, 384 tests, typecheck)
- [ ] After merge: tag `dsh-edge-v0.13.0-alpha.2`, push tag, verify npm publish and GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)