### PR TITLE
chore(release): prepare 0.13.0-alpha.3

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.13.0-alpha.2",
+  "version": "0.13.0-alpha.3",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.13.0-alpha.3.i18n.yaml
+++ b/docs/releases/0.13.0-alpha.3.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.13.0-alpha.3.md: 6209c9f28755be2107dfc5cf8d0fd26a6d0030d9
+0.13.0-alpha.3.zh.md: e5dc4f77e377a40c59aaf6f2c45bf43ef8aa78e2

--- a/docs/releases/0.13.0-alpha.3.md
+++ b/docs/releases/0.13.0-alpha.3.md
@@ -1,0 +1,9 @@
+## dsh-edge 0.13.0-alpha.3
+
+Three subagent runtime fixes found during manual verification. Published to npm's `next` channel; the stable `latest` channel is unchanged. The upstream baseline remains 0.1.2-rc.1.
+
+### Fixed
+
+- **Lineage switcher broken** (#160): the subagent typert was never registered, so the browser's `subagents/list` RPC call failed with "unexpected parentSessionId". The lineage switcher now shows child sessions after delegation.
+- **Cancel displayed `Error: [object Object]`** (#160): the cancel cause passed to `agent.cancel()` was a plain `{ kind: 'user' }` object with no `message` property. The upstream `errorMessage()` fell through to `String()` on the object. Added a `message` field to each cancel path: "cancelled by the user" for user cancel, "turn deadline exceeded" for the server-side run deadline.
+- **60 s short-tool deadline killed subagent** (#160): the short tool pool applied its execution deadline to all root tool calls, including `subagent`. Exempted the subagent tool since it runs a child agent with its own turn budget. Child tools dispatched by the child agent still go through the pool normally.

--- a/docs/releases/0.13.0-alpha.3.zh.md
+++ b/docs/releases/0.13.0-alpha.3.zh.md
@@ -1,0 +1,9 @@
+## dsh-edge 0.13.0-alpha.3
+
+手动验证中发现的三个子代理运行时问题修复。发布至 npm 的 `next` 频道；稳定的 `latest` 频道保持不变。上游基线仍为 0.1.2-rc.1。
+
+### 修复
+
+- **血缘关系切换器无法使用** (#160)：子代理 typert 从未注册，导致浏览器的 `subagents/list` RPC 调用失败并报错"unexpected parentSessionId"。现在委派后血缘关系切换器能正常显示子会话。
+- **取消时显示 `Error: [object Object]`** (#160)：传递给 `agent.cancel()` 的取消原因是一个没有 `message` 属性的普通 `{ kind: 'user' }` 对象。上游 `errorMessage()` 对该对象回退到 `String()`。已为每个取消路径添加 `message` 字段：用户取消为"cancelled by the user"，服务端运行期限为"turn deadline exceeded"。
+- **60 秒短工具期限杀死子代理** (#160)：短工具池对所有根工具调用（包括 `subagent`）施加了执行期限。已豁免子代理工具，因为它运行的子 Agent 拥有独立的 turn 预算。子 Agent 调度的子工具仍正常通过工具池。


### PR DESCRIPTION
## Summary

- Bump version to `0.13.0-alpha.3`
- Add bilingual release notes documenting the three subagent runtime fixes (#160): typert registration, cancel error display, short-tool pool exemption

## Test plan

- [x] `pnpm run check` passes (46 doc pairs, 386 tests, typecheck)
- [ ] After merge: tag `dsh-edge-v0.13.0-alpha.3`, push tag, verify npm publish and GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)