### PR TITLE
release: dsh-edge 0.13.0

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.13.0-alpha.3",
+  "version": "0.13.0",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.13.0.i18n.yaml
+++ b/docs/releases/0.13.0.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.13.0.md: 8c3f7554d392df049053250dd7bf6a2a169a04e8
+0.13.0.zh.md: 099b2e39a3e0a0910c364157ff2dd5a0657bae67

--- a/docs/releases/0.13.0.md
+++ b/docs/releases/0.13.0.md
@@ -1,0 +1,20 @@
+## dsh-edge 0.13.0
+
+One-shot subagent delegation. The upstream baseline remains 0.1.2-rc.1.
+
+### Added
+
+- **One-shot subagent delegation** (#156): the LLM can now delegate focused subtasks to a child agent running inside the same Durable Object. The upstream `dsh-subagent` runtime, `spawn-in-process` provider, and `dsh-tool-subagent` are mounted as-is. The child agent shares the parent's workspace VFS, shell backend, and LLM adapter. Delegation depth is capped at one level (`maxDepth: 1`); background and continuable modes are not enabled.
+- **Automatic child shell binding**: child agents inherit the parent's Computer shell binding through an `agent/created` listener. Disposal releases the child binding automatically.
+- **Subagent session events**: child session events are broadcast through the existing mux WebSocket downlink. The upstream lineage switcher in the browser banner shows child sessions when subagents are active.
+
+### Changed
+
+- **Standalone gzip budget raised to 3 MiB**: Cloudflare removed the compressed Worker size limit on 2026-09-04 (new limit: 64 MiB uncompressed, free and paid plans unified). The repository budget remains as a code-size guardrail but no longer corresponds to a platform constraint. The subagent packages add approximately 22 KiB gzip to the direct Worker bundle.
+- **Subagent tool exempt from the short-tool pool** (#160): the 60-second short-tool execution deadline no longer applies to the `subagent` tool, which runs a child agent with its own turn budget. Child tools dispatched by the child agent still go through the pool normally.
+
+### Fixed
+
+- **Subagent preset interface** (#158): the upstream `dsh-subagent` runtime calls `composedPreset()` and `composeFrom()` on the `agentPresets` service when creating a child agent. Added both methods to `EdgeAgentPresets` so subagent creation no longer throws `composedPreset is not a function`.
+- **Subagent typert registration** (#160): the subagent typert was never registered, so the browser's `subagents/list` RPC call failed. The lineage switcher now works after delegation.
+- **Cancel error display** (#160): the cancel cause passed to `agent.cancel()` was a plain object with no `message` property, rendering as `Error: [object Object]`. Added readable messages: "cancelled by the user" for user cancel, "turn deadline exceeded" for the server-side run deadline.

--- a/docs/releases/0.13.0.zh.md
+++ b/docs/releases/0.13.0.zh.md
@@ -1,0 +1,20 @@
+## dsh-edge 0.13.0
+
+一次性子代理委派。上游基线仍为 0.1.2-rc.1。
+
+### 新增
+
+- **一次性子代理委派** (#156)：LLM 现在可以将聚焦的子任务委派给在同一 Durable Object 内运行的子代理。上游 `dsh-subagent` 运行时、`spawn-in-process` 提供者和 `dsh-tool-subagent` 均已原样挂载。子代理与父代理共享工作区 VFS、Shell 后端和 LLM 适配器。委派深度上限为一级（`maxDepth: 1`）；后台模式和可续模式均未启用。
+- **自动子代理 Shell 绑定**：子代理通过 `agent/created` 监听器自动继承父代理的 Computer Shell 绑定。销毁时自动释放子代理绑定。
+- **子代理会话事件**：子会话事件通过现有的 mux WebSocket 下行链路广播。当子代理活跃时，上游血缘关系切换器在浏览器横幅中显示子会话。
+
+### 变更
+
+- **Standalone gzip 预算提高至 3 MiB**：Cloudflare 于 2026-09-04 取消了 Worker 压缩大小限制（新限制：64 MiB 未压缩，免费和付费计划统一）。仓库预算仍作为代码体积护栏保留，但不再对应平台约束。子代理包为 Direct Worker 构建增加约 22 KiB gzip。
+- **子代理工具豁免短工具池** (#160)：60 秒短工具执行期限不再适用于 `subagent` 工具，该工具运行的子 Agent 拥有独立的 turn 预算。子 Agent 调度的子工具仍正常通过工具池。
+
+### 修复
+
+- **子代理预设接口** (#158)：上游 `dsh-subagent` 运行时在创建子代理时会调用 `agentPresets` 服务的 `composedPreset()` 和 `composeFrom()` 方法。已为 `EdgeAgentPresets` 添加两个方法，子代理创建不再抛出 `composedPreset is not a function`。
+- **子代理 typert 注册** (#160)：子代理 typert 从未注册，导致浏览器的 `subagents/list` RPC 调用失败。现在委派后血缘关系切换器能正常工作。
+- **取消错误显示** (#160)：传递给 `agent.cancel()` 的取消原因是一个没有 `message` 属性的普通对象，渲染为 `Error: [object Object]`。已添加可读消息：用户取消为"cancelled by the user"，服务端运行期限为"turn deadline exceeded"。


### PR DESCRIPTION
## Summary

- Bump version to `0.13.0` (stable)
- Add bilingual release notes consolidating alpha.1–alpha.3: subagent delegation, preset fix, typert registration, cancel error display, short-tool pool exemption

## Test plan

- [x] `pnpm run check` passes (47 doc pairs, 386 tests, typecheck)
- [ ] After merge: tag `dsh-edge-v0.13.0`, push tag, verify npm publish (`latest` channel) and GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)