### PR TITLE
chore(release): prepare 0.14.0-alpha.1

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.13.0",
+  "version": "0.14.0-alpha.1",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.14.0-alpha.1.i18n.yaml
+++ b/docs/releases/0.14.0-alpha.1.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.14.0-alpha.1.md: 063fc51024d9d3cbcbaa84c13ada20cfc5e0a98a
+0.14.0-alpha.1.zh.md: 1c2ba15e00a15382db6f11230e4eb44d3182c3c0

--- a/docs/releases/0.14.0-alpha.1.md
+++ b/docs/releases/0.14.0-alpha.1.md
@@ -1,0 +1,14 @@
+## dsh-edge 0.14.0-alpha.1
+
+Background job registry and subagent background mode. Published to npm's `next` channel for testing; the stable `latest` channel is unchanged. The upstream baseline remains 0.1.2-rc.1.
+
+### Added
+
+- **Background job registry** (#163): install the upstream `LocalJobRegistry` (`dsh-jobs-local`) with a concurrency cap of 3 active jobs per owner, and the model-facing job control tools (`dsh-tool-jobs`): `job_output`, `job_list`, `job_kill`. The registry is process-local (in-memory); job state lives for the duration of the DO activation.
+- **Subagent background mode** (#163): enable `enableRunInBackground` on the subagent tool. The model can now dispatch a subagent with `run_in_background: true` to get a job id immediately and continue working on other tasks. When the child finishes, the parent receives a completion notice. The model collects results with `job_output` and cancels with `job_kill`.
+
+### Try the alpha
+
+Upgrade with `npx dsh-edge@0.14.0-alpha.1 upgrade`, or install fresh with `npx dsh-edge@0.14.0-alpha.1 install`.
+
+Suggested checks: ask the agent to run two independent research tasks as background subagents; verify it continues the conversation while both run; verify completion notices arrive and the agent collects results with `job_output`. Try `job_list` to see active jobs, and `job_kill` to cancel one mid-flight. The concurrency cap rejects a 4th concurrent job.

--- a/docs/releases/0.14.0-alpha.1.zh.md
+++ b/docs/releases/0.14.0-alpha.1.zh.md
@@ -1,0 +1,14 @@
+## dsh-edge 0.14.0-alpha.1
+
+后台任务注册表和子代理后台模式。发布至 npm 的 `next` 频道供测试；稳定的 `latest` 频道保持不变。上游基线仍为 0.1.2-rc.1。
+
+### 新增
+
+- **后台任务注册表** (#163)：安装上游 `LocalJobRegistry`（`dsh-jobs-local`），每个 owner 最多 3 个并发活跃任务，以及模型侧任务控制工具（`dsh-tool-jobs`）：`job_output`、`job_list`、`job_kill`。注册表为进程内实现（纯内存）；任务状态在 DO 激活期间有效。
+- **子代理后台模式** (#163)：启用子代理工具的 `enableRunInBackground`。模型现在可以使用 `run_in_background: true` 派出子代理，立即获得 job id 并继续处理其他任务。子代理完成后，父代理收到完成通知。模型使用 `job_output` 收集结果，使用 `job_kill` 取消任务。
+
+### 试用 Alpha 版
+
+使用 `npx dsh-edge@0.14.0-alpha.1 upgrade` 升级现有安装，或使用 `npx dsh-edge@0.14.0-alpha.1 install` 创建新安装。
+
+建议检查：要求代理将两个独立的研究任务作为后台子代理运行；验证代理在两个任务运行时继续对话；验证完成通知到达后代理使用 `job_output` 收集结果。尝试 `job_list` 查看活跃任务，以及 `job_kill` 在运行中取消一个任务。并发上限会拒绝第 4 个并发任务。


### PR DESCRIPTION
## Summary

- Bump version to `0.14.0-alpha.1`
- Add bilingual release notes for background job registry and subagent background mode (#163)

## Test plan

- [x] `pnpm run check` passes (48 doc pairs, 388 tests, typecheck)
- [ ] After merge: tag `dsh-edge-v0.14.0-alpha.1`, push tag, verify npm publish and GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)