### PR TITLE
chore(release): prepare 0.14.0-alpha.2

### DIFF
--- a/apps/dsh-edge/package.json
+++ b/apps/dsh-edge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-edge",
-  "version": "0.14.0-alpha.1",
+  "version": "0.14.0-alpha.2",
   "description": "Your DeepSeek Harness, anywhere — deploy a persistent personal coding agent to Cloudflare Workers in one command",
   "author": "pawaca",
   "license": "MIT",

--- a/docs/releases/0.14.0-alpha.2.i18n.yaml
+++ b/docs/releases/0.14.0-alpha.2.i18n.yaml
@@ -1,0 +1,6 @@
+# Bilingual-pair consistency record: the git blob hash of each side at the
+# last confirmed-consistent state. Both languages carry equal authority.
+# After editing either side, update both and re-record every pair with:
+#   pnpm run doc-pairs -- --write
+0.14.0-alpha.2.md: 1bdc0b65a19f4f92804f4bd667e29674d6754d9a
+0.14.0-alpha.2.zh.md: b16363de33c13dc5694f5760259a567de574101a

--- a/docs/releases/0.14.0-alpha.2.md
+++ b/docs/releases/0.14.0-alpha.2.md
@@ -1,0 +1,13 @@
+## dsh-edge 0.14.0-alpha.2
+
+Resident agent lifecycle. Published to npm's `next` channel; the stable `latest` channel is unchanged. The upstream baseline remains 0.1.2-rc.1.
+
+### Changed
+
+- **Resident agent across turns** (#165): agents now stay alive in idle phase between turns instead of being disposed after each turn. The upstream agent loop's idle/active state machine drives the lifecycle; `getOrResumeAgent()` caches the agent handle per session for the duration of the DO activation. Background jobs, shell bindings, workspace handles, and spill storage all persist alongside the resident agent.
+
+### Fixed
+
+- **Background jobs surviving across turns** (#165): the `LocalJobRegistry` binds job ownership to the agent's cordis scope. With per-turn dispose, jobs were deleted at the end of every turn. With a resident agent, the scope stays alive and jobs persist until the agent is explicitly disposed (session deletion or DO shutdown).
+- **Workspace handle for background subagents** (#165): the Computer workspace was opened per-turn with `using` and disposed at turn end, causing background subagents to hit a closed handle. The workspace now opens once on first turn and persists alongside the agent.
+- **Spill storage for background results** (#165): the spill store filesystem binding was unbound at turn end. Large tool results from background subagents would fail with "no workspace filesystem bound". Now bound once alongside the resident workspace.

--- a/docs/releases/0.14.0-alpha.2.zh.md
+++ b/docs/releases/0.14.0-alpha.2.zh.md
@@ -1,0 +1,13 @@
+## dsh-edge 0.14.0-alpha.2
+
+常驻 Agent 生命周期。发布至 npm 的 `next` 频道；稳定的 `latest` 频道保持不变。上游基线仍为 0.1.2-rc.1。
+
+### 变更
+
+- **Agent 跨 Turn 常驻** (#165)：Agent 现在在 turn 之间保持 idle 状态，不再在每个 turn 结束时被销毁。上游 Agent loop 的 idle/active 状态机驱动生命周期；`getOrResumeAgent()` 在 DO 激活期间按 session 缓存 agent handle。后台任务、Shell 绑定、工作区句柄和 Spill 存储都随常驻 Agent 一起保留。
+
+### 修复
+
+- **后台任务跨 Turn 保留** (#165)：`LocalJobRegistry` 通过 Agent 的 cordis scope 绑定任务所有权。之前每 turn 销毁 agent 会删除所有 job。常驻 Agent 的 scope 保持存活，job 持续存在直到 agent 被显式销毁（session 删除或 DO 关闭）。
+- **后台子代理的工作区句柄** (#165)：Computer 工作区之前每 turn 用 `using` 打开并在结束时释放，导致后台子代理访问到已关闭的句柄。现在工作区在首次 turn 时打开一次，随 Agent 常驻。
+- **后台结果的 Spill 存储** (#165)：Spill 存储的文件系统绑定之前在 turn 结束时解除。后台子代理产生的大型工具结果会报错"no workspace filesystem bound"。现在随常驻工作区一起绑定一次。


### PR DESCRIPTION
## Summary

- Bump version to `0.14.0-alpha.2`
- Add bilingual release notes for resident agent lifecycle (#165)

## Test plan

- [x] `pnpm run check` passes (49 doc pairs, 388 tests, typecheck)
- [ ] After merge: tag `dsh-edge-v0.14.0-alpha.2`, push tag, verify npm publish and GitHub Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)