### PR TITLE
feat(standalone): recognize extra npm scopes via DSH_EDGE_EXTRA_ALIAS_SCOPES

### DIFF
--- a/apps/dsh-edge/standalone/scripts/bundle-standalone.mjs
+++ b/apps/dsh-edge/standalone/scripts/bundle-standalone.mjs
@@ -12,6 +12,14 @@ import { requireGzipBudget } from '../../scripts/bundle-size.mjs'
 import { renderParsedSourceModeWranglerConfig } from '../../scripts/wrangler-config-core.mjs'
 
 const DIRECT_GZIP_BUDGET_BYTES = 3 * 1024 * 1024
+// Additional npm scopes to recognize when building the published-package alias
+// table and the runtime-dependency lock guard below, for forks that bundle their
+// own plugin packages alongside dsh-edge's own. Comma-separated npm scopes, for
+// example "@acme,@example"; empty by default so upstream behavior is unchanged.
+const extraAliasScopes = (process.env.DSH_EDGE_EXTRA_ALIAS_SCOPES ?? '')
+  .split(',')
+  .map(scope => scope.trim())
+  .filter(scope => scope.length > 0)
 const standaloneDirectory = fileURLToPath(new URL('..', import.meta.url))
 const appDirectory = resolve(standaloneDirectory, '..')
 const standaloneRequire = createRequire(join(standaloneDirectory, 'package.json'))
@@ -78,11 +86,16 @@ if (mode !== 'direct' && mode !== 'isolated') {
 
 async function publishedPackageAliases() {
   const specifiers = new Set()
+  const scopePattern = ['@deepseek-ai', '@cloudflare', ...extraAliasScopes]
+    .map(escapeRegExpLiteral)
+    .join('|')
+  const specifierPattern = new RegExp(
+    `['"]((?:${scopePattern})\/[^'"]+|(?:just-bash|fast-png|jpeg-js)(?:\/[^'"]*)?)['"]`,
+    'g',
+  )
   for (const path of await sourceFiles(join(appDirectory, 'src'))) {
     const source = await readFile(path, 'utf8')
-    for (const match of source.matchAll(
-      /['"]((?:@deepseek-ai|@cloudflare)\/[^'"]+|(?:just-bash|fast-png|jpeg-js)(?:\/[^'"]*)?)['"]/g,
-    )) {
+    for (const match of source.matchAll(specifierPattern)) {
       specifiers.add(match[1])
     }
   }
@@ -172,6 +185,11 @@ async function sourceFiles(root) {
   return files
 }
 
+/** Escape a literal npm scope (e.g. "@acme") for interpolation into a RegExp. */
+function escapeRegExpLiteral(literal) {
+  return literal.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}
+
 function packageName(specifier) {
   if (!specifier.startsWith('@')) return specifier.split('/')[0]
   return specifier.split('/').slice(0, 2).join('/')
@@ -215,6 +233,7 @@ async function requirePublishedDependencyInputs(metafilePath) {
     const isPinnedRuntimeDependency = path.includes('@deepseek-ai')
       || path.includes('@deepseek-ai+')
       || path.includes('@cloudflare+computer')
+      || extraAliasScopes.some(scope => path.includes(scope) || path.includes(`${scope}+`))
       || path.includes('just-bash')
       || path.includes('fast-png')
       || path.includes('jpeg-js')


### PR DESCRIPTION
## Problem

`apps/dsh-edge/standalone/scripts/bundle-standalone.mjs` hardcodes the npm
scopes it recognizes when building the published-package alias table
(`@deepseek-ai`, `@cloudflare`) and the runtime-dependency lock guard. A
downstream fork that bundles its own scoped plugin packages alongside
dsh-edge's own dependencies has no way to make the standalone bundler
recognize those packages without carrying a source patch against this file.

## Reproduction

Add an import from a third-party scoped package (e.g. `@acme/plugin`) that
should be treated as a published dependency by the standalone bundler. The
bundler only matches `@deepseek-ai` and `@cloudflare` specifiers (plus a
short allow-list of unscoped packages), so the new scope is silently dropped
from `publishedPackageAliases()` and never recognized as pinned by
`requirePublishedDependencyInputs()`.

## Fix

Add an optional, comma-separated `DSH_EDGE_EXTRA_ALIAS_SCOPES` environment
variable that extends the recognized scope list in both
`publishedPackageAliases()` and `requirePublishedDependencyInputs()`. A new
`escapeRegExpLiteral()` helper escapes each scope before it is interpolated
into the specifier `RegExp`. The variable defaults to empty, so upstream
behavior is byte-for-byte unchanged when it is unset.

## Compatibility

- No behavior change when `DSH_EDGE_EXTRA_ALIAS_SCOPES` is unset (default,
  matches current upstream behavior).
- No changes to the public API, build output, or existing environment
  variables.
- Additive only: one new env var, one new helper function.

## Validation

- `node --check apps/dsh-edge/standalone/scripts/bundle-standalone.mjs`
  passes.
- `oxlint` does not apply to this file: the repository's `.oxlintrc.json`
  ignores `**/*.mjs` repository-wide, so this change is not covered by the
  configured lint step.
- We have **not** run the full `pnpm run check` or the standalone build in
  this repository's environment (no local pnpm workspace set up for this
  contribution). Please run the project's standard checks before merging;
  happy to address any failures they surface.

## Context

We maintain a fork-adjacent harness (`edge-harness`) that vendors
`dsh-edge` as a standalone bundle and adds our own scoped plugin packages
on top of it. Today we carry this same change as a local source patch
applied at build time. Upstreaming it lets us drop that patch and instead
set `DSH_EDGE_EXTRA_ALIAS_SCOPES` as a build-time environment variable,
with no source divergence from `dsh-edge` itself.
